### PR TITLE
BZ-10326 fix the layout of the coverage text to appear next to buttons

### DIFF
--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.html
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.html
@@ -24,7 +24,7 @@
       }
     } @else {
       <!-- dealing with individual button options -->
-      <span>
+      <span class="ti-no-stack-container">
         @if (displayInfo.mainUrl !== '') {
           <main-button
             class="ti-single-button"

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.scss
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.scss
@@ -12,6 +12,12 @@
   }
 }
 
+.ti-no-stack-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
 .ti-consolidated-coverage {
   font-size: 0.875rem;
   color: var(--sys-primary);


### PR DESCRIPTION
## Summary - [BZ-10326](https://thirdiron.atlassian.net/browse/BZ-10326)

Fix for issue where the no-stack view was not correctly placing the journal cover statement. We want this to be next to the buttons, not on a new line.

Before:
<img width="645" height="281" alt="Screenshot 2025-12-18 at 9 08 55 AM" src="https://github.com/user-attachments/assets/18d2f5af-6cd7-4f14-80ea-65f6e1b8dbaa" />

After:
<img width="607" height="263" alt="Screenshot 2025-12-18 at 9 09 46 AM" src="https://github.com/user-attachments/assets/5f73c735-89bb-4365-8336-8be13e65f9bb" />


[BZ-10326]: https://thirdiron.atlassian.net/browse/BZ-10326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a flex container to the no-stack section so consolidated coverage displays inline with the buttons.
> 
> - **UI — Third Iron Buttons**:
>   - **HTML (`src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.html`)**: Add `ti-no-stack-container` class to the no-stack container to group buttons and coverage inline.
>   - **Styles (`src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.scss`)**: Introduce `.ti-no-stack-container` with `display: flex`, row direction, and centered alignment to keep coverage text aligned next to buttons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c6c06a1d4882dbe05251e6062bb4bc4cfc4f577. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->