### PR TITLE
BZ-10301 consistent btn order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: /feature\/.*/
+              only: develop
       - deploy-to-production:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: develop
+              only: /feature\/.*/
       - deploy-to-production:
           requires:
             - build-and-test

--- a/src/app/services/button-info.service.ts
+++ b/src/app/services/button-info.service.ts
@@ -169,9 +169,22 @@ export class ButtonInfoService {
       displayInfo: DEFAULT_DISPLAY_WATERFALL_RESPONSE,
     };
 
+    this.debugLog.debug('ButtonInfo.displayWaterfall.start', {
+      entityType: type,
+      status: (response as any)?.status ?? null,
+      hasData: !!data,
+      isArticle: this.httpService.isArticle(data),
+      isJournal: this.httpService.isJournal(data),
+      hasIncludedJournal: !!journal,
+    });
+
     // If our response object data isn't an Article and isn't a Journal,
     // we can't proceed, so return the default empty button info
     if (!this.httpService.isArticle(data) && !this.httpService.isJournal(data)) {
+      this.debugLog.debug('ButtonInfo.displayWaterfall.defaultReturn.invalidData', {
+        entityType: type,
+        status: (response as any)?.status ?? null,
+      });
       return defaultReturn;
     }
 
@@ -296,6 +309,19 @@ export class ButtonInfoService {
       showSecondaryButton,
       showBrowzineButton,
     };
+
+    this.debugLog.debug('ButtonInfo.displayWaterfall.result', {
+      entityType: type,
+      status: (response as any)?.status ?? null,
+      mainButtonType: buttonType,
+      mainUrl: linkUrl ? this.debugLog.redactUrlTokens(linkUrl) : '',
+      showSecondaryButton,
+      secondaryUrl: secondaryButtonUrl
+        ? this.debugLog.redactUrlTokens(secondaryButtonUrl)
+        : '',
+      showBrowzineButton,
+      browzineUrl: browzineWebLink ? this.debugLog.redactUrlTokens(browzineWebLink) : '',
+    });
 
     return {
       displayInfo,

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.html
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.html
@@ -38,15 +38,15 @@
           @if (displayInfo.showSecondaryButton && displayInfo.secondaryUrl) {
             <article-link-button class="ti-single-button" [url]="displayInfo.secondaryUrl || ''"></article-link-button>
           }
+          @if (primoLinks.length > 0) {
+            <stacked-dropdown [links]="primoLinks"></stacked-dropdown>
+          }
           @if (displayInfo.showBrowzineButton && displayInfo.browzineUrl) {
             <custom-browzine-button
               class="ti-single-button"
               [entityType]="displayInfo.entityType"
               [url]="displayInfo.browzineUrl"
             ></custom-browzine-button>
-          }
-          @if (primoLinks.length > 0) {
-            <stacked-dropdown [links]="primoLinks"></stacked-dropdown>
           }
           @if (viewModel.consolidatedCoverage) {
             <div class="ti-consolidated-coverage">

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
@@ -211,79 +211,77 @@ describe('ThirdIronButtonsComponent', () => {
       expect(el.querySelector('.ti-consolidated-coverage')).toBeNull();
     });
 
-    it('StackPlusBrowzine: renders merged stack dropdown + Browzine button when both are present', async () => {
-      const { el } = await setupRender({
-        viewOption: ViewOptionType.StackPlusBrowzine,
-        // Mirrors buildStackOptions()/buildCombinedLinks() output: TI + (optional) Primo links.
-        combinedLinks: [
-          {
-            source: 'thirdIron',
-            entityType: EntityType.Article,
-            mainButtonType: ButtonType.ArticleLink,
-            url: 'https://example.com/merged',
-            ariaLabel: '',
-            label: '',
-          },
-          {
-            entityType: 'directLink',
-            url: '/fulldisplay?docid=123#nui.getit.service_viewit',
-            ariaLabel: '',
-            source: 'directLink',
-            label: 'Other online options',
-          },
-        ],
-        displayInfo: {
-          ...baseDisplayInfo,
-          showBrowzineButton: true,
-          browzineUrl: 'https://example.com/browzine',
+    describe('StackPlusBrowzine', () => {
+      const baseStackPlusCombinedLinks = [
+        {
+          source: 'thirdIron',
+          entityType: EntityType.Article,
+          mainButtonType: ButtonType.ArticleLink,
+          url: 'https://example.com/merged',
+          ariaLabel: '',
+          label: '',
         },
+      ];
+
+      const renderStackPlusBrowzine = async (opts?: { combinedLinks?: any[]; displayInfo?: any }) => {
+        const { el } = await setupRender({
+          viewOption: ViewOptionType.StackPlusBrowzine,
+          combinedLinks: opts?.combinedLinks ?? baseStackPlusCombinedLinks,
+          displayInfo: opts?.displayInfo ?? baseDisplayInfo,
+        });
+
+        const container = el.querySelector('.ti-stack-options-container');
+        expect(container).withContext(el.innerHTML).not.toBeNull();
+        expect(container?.querySelectorAll('stacked-dropdown').length).toBe(1);
+
+        return { el, container };
+      };
+
+      it('renders merged stack dropdown + Browzine button when both are present', async () => {
+        const { container } = await renderStackPlusBrowzine({
+          // Mirrors buildStackOptions()/buildCombinedLinks() output: TI + (optional) Primo links.
+          combinedLinks: [
+            ...baseStackPlusCombinedLinks,
+            {
+              entityType: 'directLink',
+              url: '/fulldisplay?docid=123#nui.getit.service_viewit',
+              ariaLabel: '',
+              source: 'directLink',
+              label: 'Other online options',
+            },
+          ],
+          displayInfo: {
+            ...baseDisplayInfo,
+            showBrowzineButton: true,
+            browzineUrl: 'https://example.com/browzine',
+          },
+        });
+
+        const browzine = container?.querySelector('custom-browzine-button') as HTMLElement | null;
+        expect(browzine).not.toBeNull();
+        expect(browzine?.classList.contains('ti-browzine-button-with-stack')).toBeTrue();
+
+        // assert that the browzine button is rendered after the stacked dropdown
+        const ordered = Array.from(
+          container?.querySelectorAll('stacked-dropdown, custom-browzine-button') ?? []
+        );
+        expect(ordered.map(n => n.tagName.toLowerCase())).toEqual([
+          'stacked-dropdown',
+          'custom-browzine-button',
+        ]);
       });
 
-      const container = el.querySelector('.ti-stack-options-container');
-      expect(container).withContext(el.innerHTML).not.toBeNull();
-
-      // this would be one button for the baseDisplayInfo article link
-      expect(container?.querySelectorAll('stacked-dropdown').length).toBe(1);
-
-      const browzine = container?.querySelector('custom-browzine-button') as HTMLElement | null;
-      expect(browzine).not.toBeNull();
-      expect(browzine?.classList.contains('ti-browzine-button-with-stack')).toBeTrue();
-
-      // assert that the browzine button is rendered after the stacked dropdown
-      const ordered = Array.from(
-        container?.querySelectorAll('stacked-dropdown, custom-browzine-button') ?? []
-      );
-      expect(ordered.map(n => n.tagName.toLowerCase())).toEqual([
-        'stacked-dropdown',
-        'custom-browzine-button',
-      ]);
-    });
-
-    it('StackPlusBrowzine: does not render Browzine button when showBrowzineButton is false (still shows dropdown)', async () => {
-      const { el } = await setupRender({
-        viewOption: ViewOptionType.StackPlusBrowzine,
-        combinedLinks: [
-          {
-            source: 'thirdIron',
-            entityType: EntityType.Article,
-            mainButtonType: ButtonType.ArticleLink,
-            url: 'https://example.com/merged',
-            ariaLabel: '',
-            label: '',
+      it('does not render Browzine button when showBrowzineButton is false (still shows dropdown)', async () => {
+        const { container } = await renderStackPlusBrowzine({
+          displayInfo: {
+            ...baseDisplayInfo,
+            showBrowzineButton: false,
+            browzineUrl: 'https://example.com/browzine',
           },
-        ],
-        displayInfo: {
-          ...baseDisplayInfo,
-          showBrowzineButton: false,
-          browzineUrl: 'https://example.com/browzine',
-        },
+        });
+
+        expect(container?.querySelector('custom-browzine-button')).toBeNull();
       });
-
-      const container = el.querySelector('.ti-stack-options-container');
-      expect(container).withContext(el.innerHTML).not.toBeNull();
-
-      expect(container?.querySelectorAll('stacked-dropdown').length).toBe(1);
-      expect(container?.querySelector('custom-browzine-button')).toBeNull();
     });
 
     it('SingleStack: renders merged stack dropdown, and never renders the individual Browzine button (Browzine is rendered as a link inside the stack dropdown)', async () => {

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
@@ -2,6 +2,9 @@ import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
+import { Component, CUSTOM_ELEMENTS_SCHEMA, Input } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { By } from '@angular/platform-browser';
 
 import { ThirdIronButtonsComponent } from './third-iron-buttons.component';
 import { SearchEntityService } from '../../services/search-entity.service';
@@ -12,6 +15,16 @@ import { ViewOptionType } from 'src/app/shared/view-option.enum';
 import { TranslateService } from '@ngx-translate/core';
 import { EntityType } from 'src/app/shared/entity-type.enum';
 import { ButtonType } from 'src/app/shared/button-type.enum';
+import { DebugLogService } from 'src/app/services/debug-log.service';
+
+@Component({
+  selector: 'stacked-dropdown',
+  standalone: true,
+  template: '',
+})
+class StackedDropdownStubComponent {
+  @Input() links: any[] = [];
+}
 
 describe('ThirdIronButtonsComponent', () => {
   // Minimal mock Store supporting select(projectionFn)
@@ -53,6 +66,321 @@ describe('ThirdIronButtonsComponent', () => {
     const fixture = TestBed.createComponent(ThirdIronButtonsComponent);
     const component = fixture.componentInstance;
     expect(component).toBeTruthy();
+  });
+
+  describe('template rendering permutations', () => {
+    beforeEach(async () => {
+      // These tests focus on ThirdIronButtonsComponent's template branching / ordering.
+      // We stub child components via CUSTOM_ELEMENTS_SCHEMA to avoid their translation effects.
+      state$ = new BehaviorSubject<any>({});
+
+      await TestBed.resetTestingModule()
+        .configureTestingModule({
+          imports: [ThirdIronButtonsComponent],
+          providers: [
+            ConfigService,
+            { provide: Store, useValue: mockStore },
+            { provide: 'MODULE_PARAMETERS', useValue: MOCK_MODULE_PARAMETERS },
+            { provide: SearchEntityService, useValue: { shouldEnhance: () => false } },
+            { provide: ButtonInfoService, useValue: {} },
+            { provide: DebugLogService, useValue: { debug: () => {}, safeSearchEntityMeta: () => ({}) } },
+            { provide: TranslateService, useValue: { stream: (key: string) => of(key) } },
+          ],
+        })
+        .overrideComponent(ThirdIronButtonsComponent, {
+          // Replace standalone imports to avoid instantiating child components.
+          set: { imports: [AsyncPipe, StackedDropdownStubComponent], schemas: [CUSTOM_ELEMENTS_SCHEMA] },
+        })
+        .compileComponents();
+    });
+
+    const baseDisplayInfo = {
+      entityType: EntityType.Article,
+      mainButtonType: ButtonType.ArticleLink,
+      mainUrl: 'https://example.com/article',
+      showSecondaryButton: false,
+      secondaryUrl: '',
+      showBrowzineButton: false,
+      browzineUrl: '',
+    };
+
+    const setupRender = async (opts?: {
+      viewOption?: ViewOptionType;
+      combinedLinks?: any[];
+      primoLinks?: any[];
+      hasThirdIronSourceItems?: boolean;
+      displayInfo?: any;
+      viewModel?: any;
+    }) => {
+      const fixture = TestBed.createComponent(ThirdIronButtonsComponent);
+      const component = fixture.componentInstance;
+
+      component.viewOption = opts?.viewOption ?? ViewOptionType.NoStack;
+      component.combinedLinks = opts?.combinedLinks ?? [];
+      component.primoLinks = opts?.primoLinks ?? [];
+      component.hasThirdIronSourceItems = opts?.hasThirdIronSourceItems ?? true;
+
+      // First pass runs the component's ngOnInit, which overwrites `displayInfo$` with the enhance pipeline.
+      // We then replace the streams with our test values (we're testing template branching, not ngOnInit).
+      fixture.detectChanges();
+
+      component.viewModel$ = of(opts?.viewModel ?? {});
+      component.displayInfo$ = of(opts?.displayInfo ?? baseDisplayInfo);
+
+      fixture.detectChanges();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      return { fixture, component, el: fixture.nativeElement as HTMLElement };
+    };
+
+    // This is simulating the case where no links were found from the Third Iron API or the Add-On config is such that no buttons
+    // for the found links should be shown. Here we test that if there are no Third Iron related links (hasThirdIronSourceItems === false),
+    // then the add-on component renders nothing (original primo content is kept).
+    it('renders nothing when hasThirdIronSourceItems is false (even if streams emit)', async () => {
+      const { el } = await setupRender({
+        hasThirdIronSourceItems: false,
+        // Use realistic StackLink shapes (even though the template should render nothing in this case).
+        combinedLinks: [
+          {
+            source: 'thirdIron',
+            entityType: EntityType.Article,
+            mainButtonType: ButtonType.ArticleLink,
+            url: 'https://example.com',
+            ariaLabel: '',
+            label: '',
+          },
+        ],
+        primoLinks: [
+          {
+            entityType: 'directLink',
+            url: 'https://example.com',
+            ariaLabel: '',
+            source: 'directLink',
+            label: 'Other online options',
+          },
+        ],
+        displayInfo: {
+          ...baseDisplayInfo,
+          showBrowzineButton: true,
+          browzineUrl: 'https://example.com/browzine',
+        },
+        viewModel: { consolidatedCoverage: '1999-2000' },
+      });
+
+      expect(el.querySelector('.ti-stack-options-container')).toBeNull();
+      expect(el.querySelector('.ti-no-stack-container')).toBeNull();
+      expect(el.querySelector('.ti-consolidated-coverage')).toBeNull();
+    });
+
+    it('StackPlusBrowzine: renders merged stack dropdown + Browzine button when both are present', async () => {
+      const { el } = await setupRender({
+        viewOption: ViewOptionType.StackPlusBrowzine,
+        // Mirrors buildStackOptions()/buildCombinedLinks() output: TI + (optional) Primo links.
+        combinedLinks: [
+          {
+            source: 'thirdIron',
+            entityType: EntityType.Article,
+            mainButtonType: ButtonType.ArticleLink,
+            url: 'https://example.com/merged',
+            ariaLabel: '',
+            label: '',
+          },
+          {
+            entityType: 'directLink',
+            url: '/fulldisplay?docid=123#nui.getit.service_viewit',
+            ariaLabel: '',
+            source: 'directLink',
+            label: 'Other online options',
+          },
+        ],
+        displayInfo: {
+          ...baseDisplayInfo,
+          showBrowzineButton: true,
+          browzineUrl: 'https://example.com/browzine',
+        },
+      });
+
+      const container = el.querySelector('.ti-stack-options-container');
+      expect(container).withContext(el.innerHTML).not.toBeNull();
+
+      // this would be one button for the baseDisplayInfo article link
+      expect(container?.querySelectorAll('stacked-dropdown').length).toBe(1);
+
+      const browzine = container?.querySelector('custom-browzine-button') as HTMLElement | null;
+      expect(browzine).not.toBeNull();
+      expect(browzine?.classList.contains('ti-browzine-button-with-stack')).toBeTrue();
+
+      // assert that the browzine button is rendered after the stacked dropdown
+      const ordered = Array.from(
+        container?.querySelectorAll('stacked-dropdown, custom-browzine-button') ?? []
+      );
+      expect(ordered.map(n => n.tagName.toLowerCase())).toEqual([
+        'stacked-dropdown',
+        'custom-browzine-button',
+      ]);
+    });
+
+    it('StackPlusBrowzine: does not render Browzine button when showBrowzineButton is false (still shows dropdown)', async () => {
+      const { el } = await setupRender({
+        viewOption: ViewOptionType.StackPlusBrowzine,
+        combinedLinks: [
+          {
+            source: 'thirdIron',
+            entityType: EntityType.Article,
+            mainButtonType: ButtonType.ArticleLink,
+            url: 'https://example.com/merged',
+            ariaLabel: '',
+            label: '',
+          },
+        ],
+        displayInfo: {
+          ...baseDisplayInfo,
+          showBrowzineButton: false,
+          browzineUrl: 'https://example.com/browzine',
+        },
+      });
+
+      const container = el.querySelector('.ti-stack-options-container');
+      expect(container).withContext(el.innerHTML).not.toBeNull();
+
+      expect(container?.querySelectorAll('stacked-dropdown').length).toBe(1);
+      expect(container?.querySelector('custom-browzine-button')).toBeNull();
+    });
+
+    it('SingleStack: renders merged stack dropdown, and never renders the individual Browzine button (Browzine is rendered as a link inside the stack dropdown)', async () => {
+      const { fixture, el } = await setupRender({
+        viewOption: ViewOptionType.SingleStack,
+        // In SingleStack, any BrowZine entry should be represented as a link inside the single dropdown,
+        // rather than rendering a separate <custom-browzine-button>.
+        combinedLinks: [
+          // Mirrors the shape produced by ButtonInfoService.buildCombinedLinks() for TI main button.
+          {
+            source: 'thirdIron',
+            entityType: EntityType.Article,
+            mainButtonType: ButtonType.ArticleLink,
+            url: 'https://example.com/merged',
+            ariaLabel: '',
+            label: '',
+          },
+          // Mirrors the shape produced by ButtonInfoService.buildCombinedLinks() for SingleStack BrowZine.
+          {
+            source: 'thirdIron',
+            entityType: EntityType.Article,
+            mainButtonType: ButtonType.Browzine,
+            url: 'https://example.com/browzine',
+          },
+        ],
+        displayInfo: {
+          ...baseDisplayInfo,
+          showBrowzineButton: true,
+          browzineUrl: 'https://example.com/browzine',
+        },
+      });
+
+      const container = el.querySelector('.ti-stack-options-container');
+      expect(container).withContext(el.innerHTML).not.toBeNull();
+
+      expect(container?.querySelectorAll('stacked-dropdown').length).toBe(1);
+      expect(container?.querySelector('custom-browzine-button')).toBeNull(); // individual Browzine button is not rendered
+
+      // Verify the BrowZine entry is passed into the stacked dropdown's [links] input.
+      const dropdownDe = fixture.debugElement.query(By.directive(StackedDropdownStubComponent));
+      expect(dropdownDe).withContext(el.innerHTML).not.toBeNull();
+
+      const dropdownCmp = dropdownDe.componentInstance as StackedDropdownStubComponent;
+      expect(Array.isArray(dropdownCmp.links)).toBeTrue();
+      expect(dropdownCmp.links.length).toBe(2);
+      expect(dropdownCmp.links.some(l => l?.url === 'https://example.com/browzine')).toBeTrue();
+      expect(dropdownCmp.links.some(l => l?.mainButtonType === ButtonType.Browzine)).toBeTrue();
+    });
+
+    it('NoStack: renders main + secondary + Primo dropdown + Browzine, with Primo dropdown before Browzine (ordering regression test)', async () => {
+      const { el } = await setupRender({
+        viewOption: ViewOptionType.NoStack,
+        combinedLinks: [],
+        primoLinks: [
+          // Mirrors buildPrimoLinks()/buildStackOptions() output: Primo online links are StackLink[].
+          {
+            entityType: 'HTML',
+            url: 'https://example.com/ro',
+            ariaLabel: '',
+            source: 'quicklink',
+            label: 'Read Online',
+          },
+          {
+            entityType: 'PDF',
+            url: 'https://example.com/pdf',
+            ariaLabel: '',
+            source: 'quicklink',
+            label: 'Get PDF',
+          },
+        ],
+        displayInfo: {
+          ...baseDisplayInfo,
+          mainUrl: 'https://example.com/article',
+          showSecondaryButton: true,
+          secondaryUrl: 'https://example.com/secondary',
+          showBrowzineButton: true,
+          browzineUrl: 'https://example.com/browzine',
+        },
+      });
+
+      const container = el.querySelector('.ti-no-stack-container');
+      expect(container).withContext(el.innerHTML).not.toBeNull();
+
+      expect(container?.querySelectorAll('main-button').length).toBe(1); // Third Iron main button
+      expect(container?.querySelectorAll('article-link-button').length).toBe(1); // Third Iron secondary button
+      expect(container?.querySelectorAll('stacked-dropdown').length).toBe(1); // for Primo links
+      expect(container?.querySelectorAll('custom-browzine-button').length).toBe(1); // individual Browzine button
+
+      const ordered = Array.from(
+        container?.querySelectorAll('main-button, article-link-button, stacked-dropdown, custom-browzine-button') ??
+          []
+      );
+
+      // assert that the buttons are rendered in the correct order:
+      // Third Iron main button, Third Iron secondary button, Primo links, individual Browzine button
+      expect(ordered.map(n => n.tagName.toLowerCase())).toEqual([
+        'main-button',
+        'article-link-button',
+        'stacked-dropdown',
+        'custom-browzine-button',
+      ]);
+    });
+
+    it('NoStack: does not render Primo dropdown when primoLinks is empty', async () => {
+      const { el } = await setupRender({
+        viewOption: ViewOptionType.NoStack,
+        combinedLinks: [],
+        primoLinks: [],
+        displayInfo: {
+          ...baseDisplayInfo,
+          showBrowzineButton: true,
+          browzineUrl: 'https://example.com/browzine',
+        },
+      });
+
+      const container = el.querySelector('.ti-no-stack-container');
+      expect(container).withContext(el.innerHTML).not.toBeNull();
+
+      expect(container?.querySelector('stacked-dropdown')).toBeNull();
+      expect(container?.querySelector('custom-browzine-button')).not.toBeNull();
+    });
+
+    it('renders consolidated coverage when present on the viewModel', async () => {
+      const { el } = await setupRender({
+        viewOption: ViewOptionType.NoStack,
+        combinedLinks: [],
+        primoLinks: [],
+        viewModel: { consolidatedCoverage: 'Coverage: 2010 - present' },
+      });
+
+      const cov = el.querySelector('.ti-consolidated-coverage');
+      expect(cov).withContext(el.innerHTML).not.toBeNull();
+      expect(cov?.textContent ?? '').toContain('Coverage: 2010 - present');
+    });
   });
 
   describe('hasThirdIronAdditions', () => {

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
-import { Component, CUSTOM_ELEMENTS_SCHEMA, Input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
 import { By } from '@angular/platform-browser';
 
@@ -24,6 +24,35 @@ import { DebugLogService } from 'src/app/services/debug-log.service';
 })
 class StackedDropdownStubComponent {
   @Input() links: any[] = [];
+}
+
+@Component({
+  selector: 'main-button',
+  standalone: true,
+  template: '',
+})
+class MainButtonStubComponent {
+  @Input() url = '';
+  @Input() buttonType: any;
+}
+
+@Component({
+  selector: 'article-link-button',
+  standalone: true,
+  template: '',
+})
+class ArticleLinkButtonStubComponent {
+  @Input() url = '';
+}
+
+@Component({
+  selector: 'custom-browzine-button',
+  standalone: true,
+  template: '',
+})
+class BrowzineButtonStubComponent {
+  @Input() entityType: any;
+  @Input() url = '';
 }
 
 describe('ThirdIronButtonsComponent', () => {
@@ -71,7 +100,7 @@ describe('ThirdIronButtonsComponent', () => {
   describe('template rendering permutations', () => {
     beforeEach(async () => {
       // These tests focus on ThirdIronButtonsComponent's template branching / ordering.
-      // We stub child components via CUSTOM_ELEMENTS_SCHEMA to avoid their translation effects.
+      // We stub child components to keep tests focused on template branching / ordering.
       state$ = new BehaviorSubject<any>({});
 
       await TestBed.resetTestingModule()
@@ -89,7 +118,15 @@ describe('ThirdIronButtonsComponent', () => {
         })
         .overrideComponent(ThirdIronButtonsComponent, {
           // Replace standalone imports to avoid instantiating child components.
-          set: { imports: [AsyncPipe, StackedDropdownStubComponent], schemas: [CUSTOM_ELEMENTS_SCHEMA] },
+          set: {
+            imports: [
+              AsyncPipe,
+              StackedDropdownStubComponent,
+              MainButtonStubComponent,
+              ArticleLinkButtonStubComponent,
+              BrowzineButtonStubComponent,
+            ],
+          },
         })
         .compileComponents();
     });

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
@@ -194,6 +194,10 @@ export class ThirdIronButtonsComponent {
                 primoLinkLabels
               );
 
+              this.debugLog.debug('ThirdIronButtons.combinedLinks', {
+                combinedLinks: this.combinedLinks,
+              });
+
               // remove Primo generated buttons/stack if we have a custom stack (with TI added items)
               if (this.combinedLinks.length > 0) {
                 const hostElem = this.elementRef.nativeElement; // this component's template element


### PR DESCRIPTION
## Summary - [BZ-10301](https://thirdiron.atlassian.net/browse/BZ-10301)

Small tweak to make sure that individual BrowZine buttons are shown last in the list of buttons. Especially for the no-stack view for Journals, but this should be consistent across all view options types and articles or journals.

The main change here was to add some tests for the button display logic. 
The functional change was a small ordering swap for the no-stack view template 


[BZ-10301]: https://thirdiron.atlassian.net/browse/BZ-10301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures consistent button ordering and improves observability and test coverage.
> 
> - Reorders `third-iron-buttons.component.html` (NoStack) so `stacked-dropdown` (Primo links) renders before the individual `custom-browzine-button`
> - Adds comprehensive unit tests for template branching/ordering across `NoStack`, `SingleStack`, and `StackPlusBrowzine`, including coverage text rendering and hasThirdIronAdditions logic
> - Adds detailed debug logs in `ButtonInfoService.displayWaterfall(...)` (start, invalid data early-return, result with redacted URLs) and in `ThirdIronButtonsComponent` after building `combinedLinks`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a311a081b953f2a1f02f3b3907152b2d5a083c50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->