### PR TITLE
BZ-10421 fix duplicate messages/buttons 

### DIFF
--- a/src/app/components/base-button/base-button.component.scss
+++ b/src/app/components/base-button/base-button.component.scss
@@ -9,10 +9,27 @@
   line-height: 32px;
   white-space: nowrap;
 
+  /*
+   * Angular Material (MDC) wraps button content in `.mdc-button__label`
+   * and may set `white-space: normal` there. Force single-line and
+   * keep the label from wrapping.
+   */
+  .mdc-button__label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    white-space: nowrap !important;
+  }
+
   .ti-custom-button-text {
     display: flex;
     align-items: center;
     gap: 8px;
+
+    // prevent the icon from shrinking
+    custom-svg-icon {
+      flex: 0 0 auto;
+    }
   }
 }
 

--- a/src/app/third-iron-module/mat-select-overrides.scss
+++ b/src/app/third-iron-module/mat-select-overrides.scss
@@ -43,6 +43,7 @@
       align-items: center;
       justify-content: center;
       gap: 8px;
+      white-space: nowrap !important;
       .quicklink-button-text {
         font-size: 14px;
       }
@@ -180,6 +181,7 @@
           align-items: center;
           justify-content: center;
           gap: 8px;
+          white-space: nowrap !important;
           .quicklink-button-text {
             font-size: 14px;
           }

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
@@ -285,126 +285,203 @@ describe('ThirdIronButtonsComponent', () => {
 
         expect(container?.querySelector('custom-browzine-button')).toBeNull();
       });
-    });
 
-    it('SingleStack: renders merged stack dropdown, and never renders the individual Browzine button (Browzine is rendered as a link inside the stack dropdown)', async () => {
-      const { fixture, el } = await setupRender({
-        viewOption: ViewOptionType.SingleStack,
-        // In SingleStack, any BrowZine entry should be represented as a link inside the single dropdown,
-        // rather than rendering a separate <custom-browzine-button>.
-        combinedLinks: [
-          // Mirrors the shape produced by ButtonInfoService.buildCombinedLinks() for TI main button.
-          {
-            source: 'thirdIron',
-            entityType: EntityType.Article,
-            mainButtonType: ButtonType.ArticleLink,
-            url: 'https://example.com/merged',
-            ariaLabel: '',
-            label: '',
+      it('renders consolidated coverage next to the stack dropdown when present', async () => {
+        const { el } = await setupRender({
+          viewOption: ViewOptionType.StackPlusBrowzine,
+          combinedLinks: baseStackPlusCombinedLinks,
+          primoLinks: [],
+          displayInfo: {
+            ...baseDisplayInfo,
+            showBrowzineButton: true,
+            browzineUrl: 'https://example.com/browzine',
           },
-          // Mirrors the shape produced by ButtonInfoService.buildCombinedLinks() for SingleStack BrowZine.
-          {
-            source: 'thirdIron',
-            entityType: EntityType.Article,
-            mainButtonType: ButtonType.Browzine,
-            url: 'https://example.com/browzine',
-          },
-        ],
-        displayInfo: {
-          ...baseDisplayInfo,
-          showBrowzineButton: true,
-          browzineUrl: 'https://example.com/browzine',
-        },
+          viewModel: { consolidatedCoverage: 'Coverage: 2010 - present' },
+        });
+
+        const cov = el.querySelector('.ti-stack-options-container .ti-consolidated-coverage');
+        expect(cov).withContext(el.innerHTML).not.toBeNull();
+        expect(cov?.textContent ?? '').toContain('Coverage: 2010 - present');
       });
 
-      const container = el.querySelector('.ti-stack-options-container');
-      expect(container).withContext(el.innerHTML).not.toBeNull();
+      it('BrowZine-only (combinedLinks empty): still renders consolidated coverage in the fallback buttons container', async () => {
+        const { el } = await setupRender({
+          viewOption: ViewOptionType.StackPlusBrowzine,
+          combinedLinks: [],
+          primoLinks: [],
+          displayInfo: {
+            ...baseDisplayInfo,
+            // No main/secondary; only BrowZine should render.
+            mainUrl: '',
+            mainButtonType: ButtonType.None,
+            showSecondaryButton: false,
+            secondaryUrl: '',
+            showBrowzineButton: true,
+            browzineUrl: 'https://example.com/browzine',
+          },
+          viewModel: { consolidatedCoverage: 'Coverage: 2010 - present' },
+        });
 
-      expect(container?.querySelectorAll('stacked-dropdown').length).toBe(1);
-      expect(container?.querySelector('custom-browzine-button')).toBeNull(); // individual Browzine button is not rendered
+        const container = el.querySelector('.ti-no-stack-container');
+        expect(container).withContext(el.innerHTML).not.toBeNull();
+        expect(container?.querySelector('custom-browzine-button')).withContext(el.innerHTML).not.toBeNull();
 
-      // Verify the BrowZine entry is passed into the stacked dropdown's [links] input.
-      const dropdownDe = fixture.debugElement.query(By.directive(StackedDropdownStubComponent));
-      expect(dropdownDe).withContext(el.innerHTML).not.toBeNull();
-
-      const dropdownCmp = dropdownDe.componentInstance as StackedDropdownStubComponent;
-      expect(Array.isArray(dropdownCmp.links)).toBeTrue();
-      expect(dropdownCmp.links.length).toBe(2);
-      expect(dropdownCmp.links.some(l => l?.url === 'https://example.com/browzine')).toBeTrue();
-      expect(dropdownCmp.links.some(l => l?.mainButtonType === ButtonType.Browzine)).toBeTrue();
+        const cov = container?.querySelector('.ti-consolidated-coverage');
+        expect(cov).withContext(el.innerHTML).not.toBeNull();
+        expect(cov?.textContent ?? '').toContain('Coverage: 2010 - present');
+      });
     });
 
-    it('NoStack: renders main + secondary + Primo dropdown + Browzine, with Primo dropdown before Browzine (ordering regression test)', async () => {
-      const { el } = await setupRender({
-        viewOption: ViewOptionType.NoStack,
-        combinedLinks: [],
-        primoLinks: [
-          // Mirrors buildPrimoLinks()/buildStackOptions() output: Primo online links are StackLink[].
-          {
-            entityType: 'HTML',
-            url: 'https://example.com/ro',
-            ariaLabel: '',
-            source: 'quicklink',
-            label: 'Read Online',
+    describe('SingleStack', () => {
+      it('renders merged stack dropdown, and never renders the individual Browzine button (BrowZine is rendered as a link inside the stack dropdown)', async () => {
+        const { fixture, el } = await setupRender({
+          viewOption: ViewOptionType.SingleStack,
+          // In SingleStack, any BrowZine entry should be represented as a link inside the single dropdown,
+          // rather than rendering a separate <custom-browzine-button>.
+          combinedLinks: [
+            // Mirrors the shape produced by ButtonInfoService.buildCombinedLinks() for TI main button.
+            {
+              source: 'thirdIron',
+              entityType: EntityType.Article,
+              mainButtonType: ButtonType.ArticleLink,
+              url: 'https://example.com/merged',
+              ariaLabel: '',
+              label: '',
+            },
+            // Mirrors the shape produced by ButtonInfoService.buildCombinedLinks() for SingleStack BrowZine.
+            {
+              source: 'thirdIron',
+              entityType: EntityType.Article,
+              mainButtonType: ButtonType.Browzine,
+              url: 'https://example.com/browzine',
+            },
+          ],
+          displayInfo: {
+            ...baseDisplayInfo,
+            showBrowzineButton: true,
+            browzineUrl: 'https://example.com/browzine',
           },
-          {
-            entityType: 'PDF',
-            url: 'https://example.com/pdf',
-            ariaLabel: '',
-            source: 'quicklink',
-            label: 'Get PDF',
-          },
-        ],
-        displayInfo: {
-          ...baseDisplayInfo,
-          mainUrl: 'https://example.com/article',
-          showSecondaryButton: true,
-          secondaryUrl: 'https://example.com/secondary',
-          showBrowzineButton: true,
-          browzineUrl: 'https://example.com/browzine',
-        },
+        });
+
+        const container = el.querySelector('.ti-stack-options-container');
+        expect(container).withContext(el.innerHTML).not.toBeNull();
+
+        expect(container?.querySelectorAll('stacked-dropdown').length).toBe(1);
+        expect(container?.querySelector('custom-browzine-button')).toBeNull(); // individual Browzine button is not rendered
+
+        // Verify the BrowZine entry is passed into the stacked dropdown's [links] input.
+        const dropdownDe = fixture.debugElement.query(By.directive(StackedDropdownStubComponent));
+        expect(dropdownDe).withContext(el.innerHTML).not.toBeNull();
+
+        const dropdownCmp = dropdownDe.componentInstance as StackedDropdownStubComponent;
+        expect(Array.isArray(dropdownCmp.links)).toBeTrue();
+        expect(dropdownCmp.links.length).toBe(2);
+        expect(dropdownCmp.links.some(l => l?.url === 'https://example.com/browzine')).toBeTrue();
+        expect(dropdownCmp.links.some(l => l?.mainButtonType === ButtonType.Browzine)).toBeTrue();
       });
 
-      const container = el.querySelector('.ti-no-stack-container');
-      expect(container).withContext(el.innerHTML).not.toBeNull();
+      it('renders consolidated coverage next to the stack dropdown when present', async () => {
+        const { el } = await setupRender({
+          viewOption: ViewOptionType.SingleStack,
+          combinedLinks: [
+            {
+              source: 'thirdIron',
+              entityType: EntityType.Article,
+              mainButtonType: ButtonType.ArticleLink,
+              url: 'https://example.com/merged',
+              ariaLabel: '',
+              label: '',
+            },
+          ],
+          primoLinks: [],
+          displayInfo: {
+            ...baseDisplayInfo,
+            showBrowzineButton: false,
+            browzineUrl: '',
+          },
+          viewModel: { consolidatedCoverage: 'Coverage: 2010 - present' },
+        });
 
-      expect(container?.querySelectorAll('main-button').length).toBe(1); // Third Iron main button
-      expect(container?.querySelectorAll('article-link-button').length).toBe(1); // Third Iron secondary button
-      expect(container?.querySelectorAll('stacked-dropdown').length).toBe(1); // for Primo links
-      expect(container?.querySelectorAll('custom-browzine-button').length).toBe(1); // individual Browzine button
-
-      const ordered = Array.from(
-        container?.querySelectorAll('main-button, article-link-button, stacked-dropdown, custom-browzine-button') ??
-          []
-      );
-
-      // assert that the buttons are rendered in the correct order:
-      // Third Iron main button, Third Iron secondary button, Primo links, individual Browzine button
-      expect(ordered.map(n => n.tagName.toLowerCase())).toEqual([
-        'main-button',
-        'article-link-button',
-        'stacked-dropdown',
-        'custom-browzine-button',
-      ]);
+        const cov = el.querySelector('.ti-stack-options-container .ti-consolidated-coverage');
+        expect(cov).withContext(el.innerHTML).not.toBeNull();
+        expect(cov?.textContent ?? '').toContain('Coverage: 2010 - present');
+      });
     });
 
-    it('NoStack: does not render Primo dropdown when primoLinks is empty', async () => {
-      const { el } = await setupRender({
-        viewOption: ViewOptionType.NoStack,
-        combinedLinks: [],
-        primoLinks: [],
-        displayInfo: {
-          ...baseDisplayInfo,
-          showBrowzineButton: true,
-          browzineUrl: 'https://example.com/browzine',
-        },
+    describe('NoStack', () => {
+      it('renders main + secondary + Primo dropdown + Browzine, with Primo dropdown before Browzine (ordering regression test)', async () => {
+        const { el } = await setupRender({
+          viewOption: ViewOptionType.NoStack,
+          combinedLinks: [],
+          primoLinks: [
+            // Mirrors buildPrimoLinks()/buildStackOptions() output: Primo online links are StackLink[].
+            {
+              entityType: 'HTML',
+              url: 'https://example.com/ro',
+              ariaLabel: '',
+              source: 'quicklink',
+              label: 'Read Online',
+            },
+            {
+              entityType: 'PDF',
+              url: 'https://example.com/pdf',
+              ariaLabel: '',
+              source: 'quicklink',
+              label: 'Get PDF',
+            },
+          ],
+          displayInfo: {
+            ...baseDisplayInfo,
+            mainUrl: 'https://example.com/article',
+            showSecondaryButton: true,
+            secondaryUrl: 'https://example.com/secondary',
+            showBrowzineButton: true,
+            browzineUrl: 'https://example.com/browzine',
+          },
+        });
+
+        const container = el.querySelector('.ti-no-stack-container');
+        expect(container).withContext(el.innerHTML).not.toBeNull();
+
+        expect(container?.querySelectorAll('main-button').length).toBe(1); // Third Iron main button
+        expect(container?.querySelectorAll('article-link-button').length).toBe(1); // Third Iron secondary button
+        expect(container?.querySelectorAll('stacked-dropdown').length).toBe(1); // for Primo links
+        expect(container?.querySelectorAll('custom-browzine-button').length).toBe(1); // individual Browzine button
+
+        const ordered = Array.from(
+          container?.querySelectorAll(
+            'main-button, article-link-button, stacked-dropdown, custom-browzine-button'
+          ) ?? []
+        );
+
+        // assert that the buttons are rendered in the correct order:
+        // Third Iron main button, Third Iron secondary button, Primo links, individual Browzine button
+        expect(ordered.map(n => n.tagName.toLowerCase())).toEqual([
+          'main-button',
+          'article-link-button',
+          'stacked-dropdown',
+          'custom-browzine-button',
+        ]);
       });
 
-      const container = el.querySelector('.ti-no-stack-container');
-      expect(container).withContext(el.innerHTML).not.toBeNull();
+      it('does not render Primo dropdown when primoLinks is empty', async () => {
+        const { el } = await setupRender({
+          viewOption: ViewOptionType.NoStack,
+          combinedLinks: [],
+          primoLinks: [],
+          displayInfo: {
+            ...baseDisplayInfo,
+            showBrowzineButton: true,
+            browzineUrl: 'https://example.com/browzine',
+          },
+        });
 
-      expect(container?.querySelector('stacked-dropdown')).toBeNull();
-      expect(container?.querySelector('custom-browzine-button')).not.toBeNull();
+        const container = el.querySelector('.ti-no-stack-container');
+        expect(container).withContext(el.innerHTML).not.toBeNull();
+
+        expect(container?.querySelector('stacked-dropdown')).toBeNull();
+        expect(container?.querySelector('custom-browzine-button')).not.toBeNull();
+      });
     });
 
     it('renders consolidated coverage when present on the viewModel', async () => {

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
@@ -193,6 +193,18 @@ export class ThirdIronButtonsComponent {
               return displayInfo;
             }
 
+            // We are enhancing this record with at least one TI-provided button (main/secondary/BrowZine).
+            // Hide the host Primo online availability UI so we don't show duplicate "Online access available"
+            // buttons alongside our custom buttons (notably, BrowZine-only records).
+            {
+              const hostElem = this.elementRef.nativeElement as HTMLElement; // this component's host element
+              const removedCount = this.removePrimoOnlineAvailability(hostElem);
+              this.debugLog.debug('ThirdIronButtons.removePrimoOnlineAvailability', {
+                reason: 'hasThirdIronSourceItems',
+                removedCount,
+              });
+            }
+
             if (viewOption !== ViewOptionType.NoStack) {
               // build custom stack options array for StackPlusBrowzine and SingleStack view options
               // Clear stale NoStack links so template can't get "stuck" on old state.
@@ -206,30 +218,13 @@ export class ThirdIronButtonsComponent {
               this.debugLog.debug('ThirdIronButtons.combinedLinks', {
                 combinedLinks: this.combinedLinks,
               });
-
-              // remove Primo generated buttons/stack if we have a custom stack (with TI added items)
-              if (this.combinedLinks.length > 0) {
-                const hostElem = this.elementRef.nativeElement; // this component's template element
-                const removedCount = this.removePrimoOnlineAvailability(hostElem);
-                this.debugLog.debug('ThirdIronButtons.removePrimoOnlineAvailability', {
-                  reason: 'combinedLinks>0',
-                  removedCount,
-                });
-              }
             } else {
               // Build array of Primo only links, filter based on TI config settings
               // Clear stale stack links (viewOption can change during lifecycle in multicampus mode).
               this.combinedLinks = [];
               this.primoLinks = this.buttonInfoService.buildPrimoLinks(viewModel, primoLinkLabels);
 
-              // remove Primo "Online Options" button or Primo's stack (quick links and direct link)
-              // Will be replaced with our own primoLinks options
-              const hostElem = this.elementRef.nativeElement; // this component's template element
-              const removedCount = this.removePrimoOnlineAvailability(hostElem);
-              this.debugLog.debug('ThirdIronButtons.removePrimoOnlineAvailability', {
-                reason: 'NoStack',
-                removedCount,
-              });
+              // Primo links are re-rendered via our own `stacked-dropdown` in NoStack mode.
             }
 
             return displayInfo;
@@ -258,21 +253,28 @@ export class ThirdIronButtonsComponent {
   }
 
   removePrimoOnlineAvailability = (hostElement: HTMLElement): number => {
-    const blockParent = hostElement?.parentElement?.parentElement ?? null;
-    if (!blockParent) {
-      this.debugLog.debug('ThirdIronButtons.removePrimoOnlineAvailability.noAncestor', {
-        hasParent: !!hostElement?.parentElement,
-      });
-      return 0;
+    // This component is injected *before* the host `nde-online-availability` block.
+    // Depending on the host (and `ngComponentOutlet`), our host element may be an `<ng-component>`
+    // node or some other wrapper. Walk up the DOM until we find an ancestor that actually contains
+    // the `nde-online-availability` element, then hide it.
+    let current: HTMLElement | null = hostElement ?? null;
+    for (let depth = 0; current && depth < 12; depth++) {
+      const onlineAvailabilityElems = current.getElementsByTagName(
+        'nde-online-availability'
+      ) as HTMLCollectionOf<HTMLElement>;
+      if (onlineAvailabilityElems.length > 0) {
+        const arr = Array.from(onlineAvailabilityElems);
+        for (const elem of arr) {
+          elem.style.display = 'none';
+        }
+        return arr.length;
+      }
+      current = current.parentElement;
     }
 
-    const elems = blockParent.getElementsByTagName(
-      'nde-online-availability'
-    ) as HTMLCollectionOf<HTMLElement>;
-    const arr = Array.from(elems);
-    for (const elem of arr) {
-      elem.style.display = 'none';
-    }
-    return arr.length;
+    this.debugLog.debug('ThirdIronButtons.removePrimoOnlineAvailability.notFound', {
+      maxDepth: 12,
+    });
+    return 0;
   };
 }

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
@@ -257,6 +257,7 @@ export class ThirdIronButtonsComponent {
     // Depending on the host (and `ngComponentOutlet`), our host element may be an `<ng-component>`
     // node or some other wrapper. Walk up the DOM until we find an ancestor that actually contains
     // the `nde-online-availability` element, then hide it.
+    // Choosing to look up the tree to a depth of 12 is arbitrary, but seemed a reasonable depth.
     let current: HTMLElement | null = hostElement ?? null;
     for (let depth = 0; current && depth < 12; depth++) {
       const onlineAvailabilityElems = current.getElementsByTagName(


### PR DESCRIPTION
update tests

## Summary - [BZ-10421](https://thirdiron.atlassian.net/browse/BZ-10421)

In the case where we were only displaying a Browzine link button with the LibKey add-on, we were not correctly removing the original 'nde-online-availability' element from the DOM. This would sometimes result in duplicate buttons or consolidated coverage statements.


## Deploy Prerequisites

- None

## Deploy Precautions

- None

## Deploy Informational Notes

- None



[BZ-10421]: https://thirdiron.atlassian.net/browse/BZ-10421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes DOM-manipulation behavior to hide host elements based on broader conditions and a new ancestor-walk search, which could inadvertently hide the wrong `nde-online-availability` in unusual DOM structures; CSS tweaks are low risk but may affect button layout across screens.
> 
> **Overview**
> Prevents duplicate Primo UI by always hiding the host `nde-online-availability` block whenever Third Iron adds any button (including *BrowZine-only* records), and makes `removePrimoOnlineAvailability` more robust by walking up the DOM to find/hide that element instead of assuming a fixed ancestor.
> 
> Updates `ThirdIronButtonsComponent` template tests to cover consolidated coverage rendering in stack views (including the BrowZine-only fallback container) and refactors/organizes the spec cases.
> 
> Adds CSS overrides to force Angular Material (MDC) button labels (`.mdc-button__label`) to stay single-line and keeps button icons from shrinking, improving layout consistency across base buttons and dropdown buttons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbc278e4c586533a06bce8d144a6c883cd785a8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->