### PR TITLE
BZ-10430 doc delivery bug

### DIFF
--- a/src/app/services/button-info.service.spec.ts
+++ b/src/app/services/button-info.service.spec.ts
@@ -254,6 +254,60 @@ describe('ButtonInfoService', () => {
         expect(shouldMakeCall).toBeTrue();
       });
 
+      it('should return false when documentDeliveryFulfillmentUrl exists and document delivery is enabled', () => {
+        const articleWithDocDeliveryOnly: ArticleData = {
+          ...articleData,
+          fullTextFile: '',
+          contentLocation: '',
+          retractionNoticeUrl: '',
+          expressionOfConcernNoticeUrl: '',
+          problematicJournalArticleNoticeUrl: '',
+          documentDeliveryFulfillmentUrl: 'https://example.com/document-delivery',
+        };
+
+        const mockApiResult: ApiResult = {
+          ...responseMetaData,
+          body: { data: articleWithDocDeliveryOnly },
+        };
+
+        const shouldMakeCall = (service as any).shouldMakeUnpaywallCall(
+          mockApiResult,
+          EntityType.Article,
+          ButtonType.DocumentDelivery
+        );
+        expect(shouldMakeCall).toBeFalse();
+      });
+
+      it('should return true when documentDeliveryFulfillmentUrl exists but document delivery is disabled', async () => {
+        const mockConfig = { ...MOCK_MODULE_PARAMETERS };
+        mockConfig.documentDeliveryFulfillmentEnabled = false;
+
+        const testBed = await createTestModule(mockConfig);
+        const testService = testBed.inject(ButtonInfoService);
+
+        const articleWithDocDeliveryOnly: ArticleData = {
+          ...articleData,
+          fullTextFile: '',
+          contentLocation: '',
+          retractionNoticeUrl: '',
+          expressionOfConcernNoticeUrl: '',
+          problematicJournalArticleNoticeUrl: '',
+          documentDeliveryFulfillmentUrl: 'https://example.com/document-delivery',
+        };
+
+        const mockApiResult: ApiResult = {
+          ...responseMetaData,
+          body: { data: articleWithDocDeliveryOnly },
+        };
+
+        const shouldMakeCall = (testService as any).shouldMakeUnpaywallCall(
+          mockApiResult,
+          EntityType.Article,
+          ButtonType.None
+        );
+        expect(shouldMakeCall).toBeTrue();
+      });
+
       it('should make Unpaywall call when ApiResult has 404 status', () => {
         // Test the 404 condition by directly testing the shouldMakeUnpaywallCall method
         const mockApiResult: ApiResult = {

--- a/src/app/services/button-info.service.ts
+++ b/src/app/services/button-info.service.ts
@@ -704,9 +704,9 @@ export class ButtonInfoService {
 
     // Doc Delivery should always supersede Unpaywall. If the article response includes a
     // documentDeliveryFulfillmentUrl (and the feature is enabled), do not fall back to Unpaywall
-    if (buttonType === ButtonType.DocumentDelivery) {
-      return false;
-    }
+    // if (buttonType === ButtonType.DocumentDelivery) {
+    //   return false;
+    // }
 
     const shouldAvoidUnpaywall = this.shouldAvoidUnpaywall(response);
     const isUnpaywallUsable = this.getUnpaywallUsable(entityType, data);

--- a/src/app/services/button-info.service.ts
+++ b/src/app/services/button-info.service.ts
@@ -704,9 +704,9 @@ export class ButtonInfoService {
 
     // Doc Delivery should always supersede Unpaywall. If the article response includes a
     // documentDeliveryFulfillmentUrl (and the feature is enabled), do not fall back to Unpaywall
-    // if (buttonType === ButtonType.DocumentDelivery) {
-    //   return false;
-    // }
+    if (buttonType === ButtonType.DocumentDelivery) {
+      return false;
+    }
 
     const shouldAvoidUnpaywall = this.shouldAvoidUnpaywall(response);
     const isUnpaywallUsable = this.getUnpaywallUsable(entityType, data);

--- a/src/app/services/button-info.service.ts
+++ b/src/app/services/button-info.service.ts
@@ -316,9 +316,7 @@ export class ButtonInfoService {
       mainButtonType: buttonType,
       mainUrl: linkUrl ? this.debugLog.redactUrlTokens(linkUrl) : '',
       showSecondaryButton,
-      secondaryUrl: secondaryButtonUrl
-        ? this.debugLog.redactUrlTokens(secondaryButtonUrl)
-        : '',
+      secondaryUrl: secondaryButtonUrl ? this.debugLog.redactUrlTokens(secondaryButtonUrl) : '',
       showBrowzineButton,
       browzineUrl: browzineWebLink ? this.debugLog.redactUrlTokens(browzineWebLink) : '',
     });
@@ -701,6 +699,12 @@ export class ButtonInfoService {
     // if we have an alert type button (retraction, EOC, problematic journal),
     // don't continue with Unpaywall call
     if (this.isAlertButton(buttonType)) {
+      return false;
+    }
+
+    // Doc Delivery should always supersede Unpaywall. If the article response includes a
+    // documentDeliveryFulfillmentUrl (and the feature is enabled), do not fall back to Unpaywall
+    if (buttonType === ButtonType.DocumentDelivery) {
       return false;
     }
 


### PR DESCRIPTION
## Summary - [BZ-10430](https://thirdiron.atlassian.net/browse/BZ-10430)

JohnS found an edge case with our doc delivery logic where we were still making a live unpaywall call which was overriding doc delivery options. We would instead like to always prioritize document delivery in this case (no unpaywall live call).


## Deploy Prerequisites

- None

## Deploy Precautions

- None

## Deploy Informational Notes

- None



[BZ-10430]: https://thirdiron.atlassian.net/browse/BZ-10430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ