### PR TITLE
BZ-10310 accessibility buttons - aria labels

### DIFF
--- a/src/app/components/browzine-button/browzine-button.component.spec.ts
+++ b/src/app/components/browzine-button/browzine-button.component.spec.ts
@@ -195,6 +195,9 @@ describe('BrowzineButtonComponent', () => {
       const textEl = stacked.querySelector('.quicklink-button-text');
       expect(textEl?.textContent || '').toContain('View Issue Contents');
 
+      const innerButton = stacked.querySelector('button');
+      expect(innerButton?.getAttribute('aria-label')).toContain('View Issue Contents');
+
       const svgIcon = stacked.querySelector('custom-svg-icon[data-testid="ti-svg-icon"]');
       expect(svgIcon).toBeTruthy();
 
@@ -225,6 +228,9 @@ describe('BrowzineButtonComponent', () => {
 
       const textEl = stacked.querySelector('.quicklink-button-text');
       expect(textEl?.textContent || '').toContain('View Journal Contents');
+
+      const innerButton = stacked.querySelector('button');
+      expect(innerButton?.getAttribute('aria-label')).toContain('View Journal Contents');
 
       const reflectType = stacked.getAttribute('ng-reflect-stack-type');
       if (reflectType !== null) {

--- a/src/app/components/main-button/main-button.component.spec.ts
+++ b/src/app/components/main-button/main-button.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MainButtonComponent } from './main-button.component';
 import { ComponentRef } from '@angular/core';
 import { ButtonType } from 'src/app/shared/button-type.enum';
+import { EntityType } from 'src/app/shared/entity-type.enum';
 import { BaseButtonComponent } from '../base-button/base-button.component';
 import { IconType } from 'src/app/shared/icon-type.enum';
 import { TranslationService } from '../../services/translation.service';
@@ -454,6 +455,33 @@ describe('MainButtonComponent', () => {
 
         const button = fixture.nativeElement.querySelector('button');
         expect(button.getAttribute('aria-label')).toContain(expectedAria);
+      }
+    });
+
+    it('should expose translated text as aria-label on inner stacked button when stack is true', async () => {
+      const stackCases = [
+        { type: ButtonType.DirectToPDF, expectedAria: 'Download PDF' },
+        { type: ButtonType.ArticleLink, expectedAria: 'Read Article' },
+      ];
+
+      for (const { type, expectedAria } of stackCases) {
+        componentRef.setInput('url', 'https://example.com');
+        componentRef.setInput('buttonType', type);
+        componentRef.setInput('stack', true);
+        componentRef.setInput('link', {
+          entityType: EntityType.Article,
+          url: 'https://example.com',
+          label: '',
+          source: 'thirdIron',
+        } as any);
+
+        fixture.autoDetectChanges();
+        await fixture.whenStable();
+
+        const stacked = fixture.nativeElement.querySelector('stacked-button');
+        expect(stacked).toBeTruthy();
+        const innerButton = stacked?.querySelector('button');
+        expect(innerButton?.getAttribute('aria-label')).toContain(expectedAria);
       }
     });
 

--- a/src/app/components/stacked-dropdown/components/stacked-button.component.html
+++ b/src/app/components/stacked-dropdown/components/stacked-button.component.html
@@ -5,7 +5,7 @@
   color="primary"
   [class.ti-dropdown-button]="stackType() === 'main'"
   [class.ti-dropdown-option-button]="stackType() === 'dropdown'"
-  [attr.aria-label]="link().ariaLabel || ''"
+  [attr.aria-label]="link().ariaLabel || link().label || ''"
   (click)="openLink()"
 >
   <span class="quicklink-button-text">

--- a/src/app/components/stacked-dropdown/components/stacked-button.component.spec.ts
+++ b/src/app/components/stacked-dropdown/components/stacked-button.component.spec.ts
@@ -71,6 +71,23 @@ describe('StackedButtonComponent', () => {
     expect(openSpy).not.toHaveBeenCalled();
   });
 
+  it('uses visible label as aria-label when ariaLabel is empty', () => {
+    const link: StackLink = {
+      entityType: 'HTML',
+      url: 'https://example.com/html',
+      source: 'quicklink',
+      label: 'Read Online',
+      ariaLabel: '',
+    };
+
+    componentRef.setInput('link', link);
+    componentRef.setInput('stackType', 'main');
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button?.getAttribute('aria-label')).toBe('Read Online');
+  });
+
   it('openLink does not navigate when stackType is dropdown', () => {
     const link: StackLink = {
       entityType: 'PDF',

--- a/src/app/services/button-info.service.spec.ts
+++ b/src/app/services/button-info.service.spec.ts
@@ -1400,14 +1400,17 @@ describe('ButtonInfoService', () => {
         ariaLabel: 'Direct link aria label',
       };
 
-      const result = testService.buildCombinedLinks(displayInfo, viewModel);
+      const result = testService.buildCombinedLinks(displayInfo, viewModel, {
+        ...DEFAULT_PRIMO_LINK_LABELS,
+        directLinkAriaLabel: 'Open in new tab',
+      });
 
       expect(result).toHaveSize(2); // 1 Third Iron + 1 direct link
       expect(result[1]).toEqual({
         source: 'directLink',
         entityType: 'directLink',
         url: 'https://example.com/nde/fulldisplay/some/direct/link#nui.getit.service_viewit',
-        ariaLabel: 'Direct link aria label',
+        ariaLabel: 'Other online options Open in new tab',
         label: 'Other online options', // From mock translation service, option when more than one item in the stack
       });
     });
@@ -1437,10 +1440,10 @@ describe('ButtonInfoService', () => {
 
       const result = testService.buildCombinedLinks(displayInfo, viewModel, {
         ...DEFAULT_PRIMO_LINK_LABELS,
-        directLinkAriaLabel: 'Translated direct link aria label',
+        directLinkAriaLabel: 'Translated Open in new tab',
       });
 
-      expect(result[1].ariaLabel).toBe('Translated direct link aria label');
+      expect(result[1].ariaLabel).toBe('Other online options Translated Open in new tab');
     });
 
     it('should label direct link as Available Online when it is the only option', async () => {
@@ -1466,14 +1469,17 @@ describe('ButtonInfoService', () => {
         ariaLabel: 'Direct link aria label',
       };
 
-      const result = testService.buildCombinedLinks(displayInfo, viewModel);
+      const result = testService.buildCombinedLinks(displayInfo, viewModel, {
+        ...DEFAULT_PRIMO_LINK_LABELS,
+        directLinkAriaLabel: 'Open in new tab',
+      });
 
       expect(result).toHaveSize(1);
       expect(result[0]).toEqual({
         source: 'directLink',
         entityType: 'directLink',
         url: 'https://example.com/nde/fulldisplay/some/direct/link#nui.getit.service_viewit',
-        ariaLabel: 'Direct link aria label',
+        ariaLabel: 'Available Online Open in new tab',
         label: 'Available Online', // From mock translation service when only one option
       });
     });

--- a/src/app/services/button-info.service.spec.ts
+++ b/src/app/services/button-info.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 
-import { ButtonInfoService } from './button-info.service';
+import { ButtonInfoService, DEFAULT_PRIMO_LINK_LABELS } from './button-info.service';
 import { HttpService } from './http.service';
 import { EntityType } from '../shared/entity-type.enum';
 import { ApiResult, ArticleData, JournalData } from '../types/tiData.types';
@@ -1410,6 +1410,37 @@ describe('ButtonInfoService', () => {
         ariaLabel: 'Direct link aria label',
         label: 'Other online options', // From mock translation service, option when more than one item in the stack
       });
+    });
+
+    it('should prefer translated direct-link aria-label from labels bundle when provided', async () => {
+      const mockConfig = { ...MOCK_MODULE_PARAMETERS };
+      mockConfig.showLinkResolverLink = true;
+
+      const testBed = await createTestModule(mockConfig);
+      const testService = testBed.inject(ButtonInfoService);
+
+      const displayInfo: DisplayWaterfallResponse = {
+        entityType: EntityType.Article,
+        mainButtonType: ButtonType.DirectToPDF,
+        mainUrl: 'https://example.com/pdf',
+        secondaryUrl: '',
+        showSecondaryButton: false,
+        showBrowzineButton: false,
+        browzineUrl: '',
+      };
+
+      const viewModel: any = {
+        onlineLinks: [],
+        directLink: 'https://example.com/nde/fulldisplay/some/direct/link',
+        ariaLabel: 'primo.directLink.aria',
+      };
+
+      const result = testService.buildCombinedLinks(displayInfo, viewModel, {
+        ...DEFAULT_PRIMO_LINK_LABELS,
+        directLinkAriaLabel: 'Translated direct link aria label',
+      });
+
+      expect(result[1].ariaLabel).toBe('Translated direct link aria label');
     });
 
     it('should label direct link as Available Online when it is the only option', async () => {

--- a/src/app/services/button-info.service.ts
+++ b/src/app/services/button-info.service.ts
@@ -526,12 +526,13 @@ export class ButtonInfoService {
       }
     }
 
+    const linkButtonLabel = hasOtherLinks ? labels.otherOptions : labels.availableOnline;
     return {
       entityType: 'directLink',
       url: this.normalizePrimoDirectLink(effectiveDirectLink),
-      ariaLabel: labels.directLinkAriaLabel || viewModel.ariaLabel || '',
+      ariaLabel: [linkButtonLabel, labels.directLinkAriaLabel].filter(Boolean).join(' '),
       source: 'directLink',
-      label: hasOtherLinks ? labels.otherOptions : labels.availableOnline,
+      label: linkButtonLabel,
     };
   }
 

--- a/src/app/services/button-info.service.ts
+++ b/src/app/services/button-info.service.ts
@@ -20,6 +20,7 @@ export type PrimoLinkTextBundle = {
   pdfText: string;
   otherOptions: string;
   availableOnline: string;
+  directLinkAriaLabel: string;
 };
 
 export const DEFAULT_PRIMO_LINK_LABELS: PrimoLinkTextBundle = {
@@ -27,6 +28,7 @@ export const DEFAULT_PRIMO_LINK_LABELS: PrimoLinkTextBundle = {
   pdfText: 'Get PDF',
   otherOptions: 'Other online options',
   availableOnline: 'Available Online',
+  directLinkAriaLabel: '',
 };
 
 /**
@@ -527,7 +529,7 @@ export class ButtonInfoService {
     return {
       entityType: 'directLink',
       url: this.normalizePrimoDirectLink(effectiveDirectLink),
-      ariaLabel: viewModel.ariaLabel || '',
+      ariaLabel: labels.directLinkAriaLabel || viewModel.ariaLabel || '',
       source: 'directLink',
       label: hasOtherLinks ? labels.otherOptions : labels.availableOnline,
     };

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
@@ -862,6 +862,7 @@ describe('ThirdIronButtonsComponent', () => {
     const pdf$ = new BehaviorSubject('Get PDF');
     const other$ = new BehaviorSubject('Other online options');
     const avail$ = new BehaviorSubject('Available Online');
+    const directAria$ = new BehaviorSubject('Open more options');
 
     const translateMock = {
       stream: (key: string) => {
@@ -874,6 +875,8 @@ describe('ThirdIronButtonsComponent', () => {
             return other$.asObservable();
           case 'delivery.code.fulltext':
             return avail$.asObservable();
+          case 'primo.directLink.aria':
+            return directAria$.asObservable();
           default:
             return of(key);
         }
@@ -883,7 +886,7 @@ describe('ThirdIronButtonsComponent', () => {
     const viewModel$ = new BehaviorSubject<any>({
       onlineLinks: [{ type: 'PDF', url: 'https://example.com/pdf', source: 'primo' }],
       directLink: '/fulldisplay?docid=123',
-      ariaLabel: '',
+      ariaLabel: 'primo.directLink.aria',
     });
 
     const buildPrimoLinksSpy = jasmine.createSpy('buildPrimoLinks').and.returnValue([]);
@@ -944,10 +947,12 @@ describe('ThirdIronButtonsComponent', () => {
       pdfText: 'Get PDF',
       otherOptions: 'Other online options',
       availableOnline: 'Available Online',
+      directLinkAriaLabel: 'Open more options',
     });
 
     // Simulate language change by emitting new translated text
     pdf$.next('PDF (FR)');
+    directAria$.next('Open more options (FR)');
     await fixture.whenStable();
 
     expect(buildPrimoLinksSpy.calls.count()).toBeGreaterThan(1);
@@ -957,7 +962,71 @@ describe('ThirdIronButtonsComponent', () => {
       pdfText: 'PDF (FR)',
       otherOptions: 'Other online options',
       availableOnline: 'Available Online',
+      directLinkAriaLabel: 'Open more options (FR)',
     });
+
+    sub?.unsubscribe();
+  });
+
+  it('passes through literal (not translation key, but actual text) direct-link aria labels unchanged', async () => {
+    const buildPrimoLinksSpy = jasmine.createSpy('buildPrimoLinks').and.returnValue([]);
+    const buttonInfoMock = {
+      getDisplayInfo: () =>
+        of({
+          entityType: EntityType.Article,
+          mainButtonType: ButtonType.ArticleLink,
+          mainUrl: 'https://example.com/article',
+          showSecondaryButton: false,
+          secondaryUrl: '',
+          showBrowzineButton: false,
+          browzineUrl: '',
+        }),
+      buildCombinedLinks: () => [],
+      buildPrimoLinks: buildPrimoLinksSpy,
+    };
+
+    await TestBed.resetTestingModule()
+      .configureTestingModule({
+        imports: [ThirdIronButtonsComponent],
+        providers: [
+          ConfigService,
+          { provide: Store, useValue: mockStore },
+          { provide: 'MODULE_PARAMETERS', useValue: MOCK_MODULE_PARAMETERS },
+          {
+            provide: TranslateService,
+            useValue: {
+              stream: (key: string) => of(key),
+            },
+          },
+        ],
+      })
+      .overrideProvider(SearchEntityService, {
+        useValue: {
+          shouldEnhanceButtons: () => true,
+        },
+      })
+      .overrideProvider(ButtonInfoService, { useValue: buttonInfoMock })
+      .compileComponents();
+
+    const fixture = TestBed.createComponent(ThirdIronButtonsComponent);
+    const component = fixture.componentInstance;
+
+    component.hostComponent = {
+      searchResult: { pnx: { control: { recordid: ['rec-2'] } } },
+      viewModel$: of({
+        onlineLinks: [{ type: 'PDF', url: 'https://example.com/pdf', source: 'primo' }],
+        directLink: '/fulldisplay?docid=456',
+        ariaLabel: 'Literal direct link aria label',
+      }),
+    };
+
+    fixture.detectChanges();
+    const sub = component.displayInfo$?.subscribe();
+    await fixture.whenStable();
+
+    expect(buildPrimoLinksSpy).toHaveBeenCalled();
+    const args = buildPrimoLinksSpy.calls.mostRecent().args;
+    expect(args[1].directLinkAriaLabel).toBe('Literal direct link aria label');
 
     sub?.unsubscribe();
   });

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
@@ -103,7 +103,17 @@ export class ThirdIronButtonsComponent {
   // the host swaps the observable instance or mutates without re-setting the @Input.
   viewModel$: Observable<PrimoViewModel> = this.hostProxy.viewModel$;
 
-  // Emits the translated Primo label strings used when building Primo links (HTML/PDF + direct-link labels).
+  private readonly directLinkAriaLabel$ = this.viewModel$.pipe(
+    map(viewModel => (viewModel?.ariaLabel ?? '').trim()),
+    distinctUntilChanged(),
+    switchMap(ariaLabel =>
+      ariaLabel ? this.translationService.getTranslatedText$(ariaLabel, ariaLabel) : of('')
+    ),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  // Emits the translated Primo label strings used when building Primo links
+  // (HTML/PDF + direct-link labels + direct-link aria-label).
   // Because it uses `translate.stream(...)` under the hood, it re-emits on language changes; `shareReplay(1)`
   // ensures the latest values are reused across subscribers without redoing the translation work.
   private readonly primoLinkLabels$ = combineLatest([
@@ -114,12 +124,14 @@ export class ThirdIronButtonsComponent {
       'Other online options'
     ),
     this.translationService.getTranslatedText$('delivery.code.fulltext', 'Available Online'),
+    this.directLinkAriaLabel$,
   ]).pipe(
-    map(([htmlText, pdfText, otherOptions, availableOnline]) => ({
+    map(([htmlText, pdfText, otherOptions, availableOnline, directLinkAriaLabel]) => ({
       htmlText,
       pdfText,
       otherOptions,
       availableOnline,
+      directLinkAriaLabel,
     })),
     shareReplay({ bufferSize: 1, refCount: true })
   );

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
@@ -30,6 +30,7 @@ import { HostComponentProxy } from 'src/app/shared/host-component-proxy';
 import {
   getPrimoHostRecordKey,
   getPrimoHostShape,
+  getPrimoViewModelMeta,
   resolvePrimoHostRecord,
 } from 'src/app/shared/primo-host-record.utils';
 import { TranslationService } from 'src/app/services/translation.service';
@@ -202,6 +203,11 @@ export class ThirdIronButtonsComponent {
           this.primoLinkLabels$,
         ]).pipe(
           map(([displayInfo, viewModel, primoLinkLabels]) => {
+            this.debugLog.debug('ThirdIronButtons.viewModel', {
+              ...getPrimoViewModelMeta(viewModel),
+              ariaLabel: viewModel?.ariaLabel ?? null,
+            });
+
             // Read once per emission; config may change (e.g. multicampus translations become available).
             const viewOption = this.viewOption;
 


### PR DESCRIPTION
## Summary - [BZ-10310](https://thirdiron.atlassian.net/browse/BZ-10310)

These changes are for fixing aria labels in the Primo link buttons and our Add-on stack buttons





[BZ-10310]: https://thirdiron.atlassian.net/browse/BZ-10310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to accessibility label construction and corresponding unit tests, with minimal impact beyond screen-reader text.
> 
> **Overview**
> Improves accessibility for stacked buttons by ensuring the rendered `<button>` always has a meaningful `aria-label`, falling back to the visible `link.label` when `link.ariaLabel` is empty.
> 
> Updates Primo direct-link label handling to include a translated/overrideable `directLinkAriaLabel` (e.g., “Open in new tab”) and composes the final `ariaLabel` from the button label plus this suffix; `ThirdIronButtonsComponent` now translates `viewModel.ariaLabel` when it is a translation key.
> 
> Adds/updates unit tests across `stacked-button`, `main-button`, `browzine-button`, `button-info.service`, and `third-iron-buttons` to assert the new `aria-label` behavior (including stack mode and translated vs literal aria label inputs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d26c1a0a3f03e34c83e21a5bce3458c726509f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->