### PR TITLE
BZ-10581 problematic journal config

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Third Iron recommended configuration JSON:
     "enableLinkOptimizer": "true",
     "articleRetractionWatchEnabled": "true",
     "articleExpressionOfConcernEnabled": "true",
+    "problematicJournalEnabled": "true",
     "documentDeliveryFulfillmentEnabled": "true",
     "articlePDFDownloadViaUnpaywallEnabled": "true",
     "articleLinkViaUnpaywallEnabled": "true",
@@ -157,6 +158,7 @@ Button label text can be customized and translated by setting up label codes in 
 3. The available label codes are as follows:
    - LibKey.articleRetractionWatchText
    - LibKey.articleExpressionOfConcernText
+   - LibKey.problematicJournalText
    - LibKey.articlePDFDownloadLinkText
    - LibKey.articleLinkText
    - LibKey.documentDeliveryFulfillmentText

--- a/src/app/components/main-button/main-button.component.spec.ts
+++ b/src/app/components/main-button/main-button.component.spec.ts
@@ -336,6 +336,29 @@ describe('MainButtonComponent', () => {
       expect(buttonTextSpan.textContent).toContain('Read Article');
     });
 
+    it('should display custom text for Problematic Journal button', async () => {
+      const customMockTranslationService = {
+        getTranslatedText$: (key: string, fallback: string) => {
+          const customTranslations: { [key: string]: string } = {
+            'LibKey.problematicJournalText': 'Custom Problematic Journal Notice',
+          };
+          return of(customTranslations[key] || fallback);
+        },
+      };
+      const testBed = await createTestModule(customMockTranslationService);
+      const customFixture = testBed.createComponent(MainButtonComponent);
+      const customComponentRef = customFixture.componentRef;
+
+      customComponentRef.setInput('url', 'www.test.com');
+      customComponentRef.setInput('buttonType', ButtonType.ProblematicJournalArticle);
+      customFixture.autoDetectChanges();
+      await customFixture.whenStable();
+
+      const customButtonElement = customFixture.nativeElement;
+      const buttonTextSpan = customButtonElement.querySelector('[data-testid="ti-button-text"]')!;
+      expect(buttonTextSpan.textContent).toContain('Custom Problematic Journal Notice');
+    });
+
     it('should display custom text for Retraction button', async () => {
       const customMockTranslationService = {
         getTranslatedText$: (key: string, fallback: string) => {

--- a/src/app/services/button-info.service.spec.ts
+++ b/src/app/services/button-info.service.spec.ts
@@ -932,6 +932,31 @@ describe('ButtonInfoService', () => {
 
         validateButton(buttonInfo, expectedValues);
       });
+      it('should not return Problematic Journal when problematicJournalEnabled is false', async () => {
+        const mockConfig = { ...MOCK_MODULE_PARAMETERS };
+        mockConfig.problematicJournalEnabled = false;
+        const testBed = await createTestModule(mockConfig);
+        const testService = testBed.inject(ButtonInfoService);
+
+        const mockedArticleData: ArticleData = {
+          ...articleData,
+          retractionNoticeUrl: '',
+          expressionOfConcernNoticeUrl: '',
+        };
+        const mockedApiResult: ApiResult = { ...responseMetaData };
+        mockedApiResult.body.data = mockedArticleData;
+        mockedApiResult.body.included = undefined;
+
+        const { displayInfo: buttonInfo } = testService.displayWaterfall(
+          mockedApiResult,
+          EntityType.Article
+        );
+
+        expect(buttonInfo.mainButtonType).toBe(ButtonType.DirectToPDF);
+        expect(buttonInfo.mainUrl).toBe(
+          'https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file'
+        );
+      });
       it('should return a Direct PDF link type button with corresponding link and image', () => {
         const mockedArticleData: ArticleData = {
           ...articleData,
@@ -1135,6 +1160,7 @@ describe('ButtonInfoService', () => {
       mockConfig.articleLinkEnabled = false;
       mockConfig.articleRetractionWatchEnabled = false;
       mockConfig.articleExpressionOfConcernEnabled = false;
+      mockConfig.problematicJournalEnabled = false;
       mockConfig.documentDeliveryFulfillmentEnabled = false;
       mockConfig.articlePDFDownloadViaUnpaywallEnabled = false;
       mockConfig.articleLinkViaUnpaywallEnabled = false;

--- a/src/app/services/button-info.service.ts
+++ b/src/app/services/button-info.service.ts
@@ -237,7 +237,11 @@ export class ButtonInfoService {
     ) {
       buttonType = ButtonType.ExpressionOfConcern;
       linkUrl = articleEocNoticeUrl;
-    } else if (problematicJournalArticleNoticeUrl && type === EntityType.Article) {
+    } else if (
+      problematicJournalArticleNoticeUrl &&
+      type === EntityType.Article &&
+      this.configService.showProblematicJournal()
+    ) {
       buttonType = ButtonType.ProblematicJournalArticle;
       linkUrl = problematicJournalArticleNoticeUrl;
     }

--- a/src/app/services/config.service.spec.ts
+++ b/src/app/services/config.service.spec.ts
@@ -12,6 +12,7 @@ export const MOCK_MODULE_PARAMETERS = {
   articleLinkEnabled: true,
   showFormatChoice: true,
   articleRetractionWatchEnabled: true,
+  problematicJournalEnabled: true,
   articleExpressionOfConcernEnabled: true,
   journalBrowZineWebLinkTextEnabled: true,
   journalCoverImagesEnabled: true,
@@ -186,6 +187,24 @@ describe('ConfigService', () => {
       const testService = testBed.inject(ConfigService);
 
       expect(testService.showRetractionWatch()).toBeFalse();
+    });
+  });
+
+  describe('showProblematicJournal', () => {
+    it('should return true when problematicJournalEnabled is true', () => {
+      expect(service.showProblematicJournal()).toBeTrue();
+    });
+
+    it('should return false when problematicJournalEnabled is false', async () => {
+      const disabledConfig = {
+        ...MOCK_MODULE_PARAMETERS,
+        problematicJournalEnabled: false,
+      };
+
+      const testBed = await createTestModule(disabledConfig);
+      const testService = testBed.inject(ConfigService);
+
+      expect(testService.showProblematicJournal()).toBeFalse();
     });
   });
 

--- a/src/app/services/config.service.spec.ts
+++ b/src/app/services/config.service.spec.ts
@@ -8,7 +8,6 @@ export const MOCK_MODULE_PARAMETERS = {
   apiKey: 'a9c7fb8f-9758-4ff9-9dc9-fcb4cbf32724',
   libraryId: '222',
   articlePDFDownloadLinkEnabled: true,
-  primoArticlePDFDownloadLinkEnabled: true,
   articleLinkEnabled: true,
   showFormatChoice: true,
   articleRetractionWatchEnabled: true,

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -139,6 +139,10 @@ export class ConfigService {
     return this.getBooleanParam('articleRetractionWatchEnabled');
   }
 
+  showProblematicJournal(): boolean {
+    return this.getBooleanParam('problematicJournalEnabled');
+  }
+
   showExpressionOfConcern(): boolean {
     return this.getBooleanParam('articleExpressionOfConcernEnabled');
   }


### PR DESCRIPTION
## Summary - [BZ-10581](https://thirdiron.atlassian.net/browse/BZ-10581)

Add config value for `problematicJournalEnabled` - this setting will control whether or not a problematic journal button is displayed.

README also updated to include this new config.



## Deploy Prerequisites

- None

## Deploy Precautions

- None

## Deploy Informational Notes

- None



[BZ-10581]: https://thirdiron.atlassian.net/browse/BZ-10581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the primary button selection waterfall for articles by gating the Problematic Journal alert behind a new config flag, which could alter which link users see in production if config is mis-set or missing.
> 
> **Overview**
> Adds a new `problematicJournalEnabled` configuration parameter to control whether the *Problematic Journal* alert button can be shown.
> 
> `ButtonInfoService.displayWaterfall` now only selects `ButtonType.ProblematicJournalArticle` when this flag is enabled; otherwise the waterfall continues to the next available option (e.g., Direct-to-PDF). Tests are updated/added to cover the new config behavior and custom label translation key (`LibKey.problematicJournalText`), and the README documents the new config and label code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4fdd043e259016a67af450e59a8385b97ea8568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->