### PR TITLE
BZ-10657 fix extra gap style

### DIFF
--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
@@ -283,6 +283,9 @@ describe('ThirdIronButtonsComponent', () => {
 
         // Spy on side-effect method to ensure enhancement pipeline didn't run.
         spyOn(component, 'removePrimoOnlineAvailability').and.callThrough();
+        // Spy on host-wrapper toggling so tests can assert we collapse the wrapping
+        // `<ng-component>` to avoid the host flex container's `gap` rule applying.
+        spyOn(component, 'hideHostWrapper').and.callThrough();
 
         fixture.detectChanges(); // runs ngOnInit
         // Ensure the Rx pipeline runs by subscribing (in the real app the template async pipe does this).
@@ -312,6 +315,17 @@ describe('ThirdIronButtonsComponent', () => {
         expect(component.removePrimoOnlineAvailability).not.toHaveBeenCalled();
         expect(el.querySelector('.ti-stack-options-container')).toBeNull();
         expect(el.querySelector('.ti-no-stack-container')).toBeNull();
+        sub?.unsubscribe();
+      });
+
+      // When we render nothing, the wrapping `<ng-component>` (a direct child of the host's
+      // `.responsive-availability-layout` flex container) still counts as a flex item, so the
+      // container's `gap: .5rem` rule adds unwanted space to the left of `<nde-online-availability>`.
+      // We hide the wrapper to avoid that gap.
+      it('hides the wrapping ng-component so the host flex container gap does not apply', async () => {
+        const { component, sub } = await setupSkipEnhancement();
+
+        expect(component.hideHostWrapper).toHaveBeenCalled();
         sub?.unsubscribe();
       });
     });
@@ -804,6 +818,10 @@ describe('ThirdIronButtonsComponent', () => {
       const { fixture, component, getDisplayInfoSpy } = await setupNavigationFixture();
       const removeSpy = spyOn(component, 'removePrimoOnlineAvailability').and.returnValue(1);
       const restoreSpy = spyOn(component, 'restorePrimoOnlineAvailability').and.returnValue(1);
+      // Track host-wrapper toggling: enhanced render should restore the wrapper, transitioning
+      // to a non-enhanced (empty render) record should collapse it again.
+      const hideWrapperSpy = spyOn(component, 'hideHostWrapper').and.returnValue(true);
+      const restoreWrapperSpy = spyOn(component, 'restoreHostWrapper').and.returnValue(true);
 
       fixture.detectChanges();
       const sub = component.displayInfo$?.subscribe();
@@ -811,6 +829,7 @@ describe('ThirdIronButtonsComponent', () => {
       fixture.detectChanges();
 
       expect(removeSpy).toHaveBeenCalled();
+      expect(restoreWrapperSpy).toHaveBeenCalled();
       expect(component.hasThirdIronSourceItems).toBeTrue();
 
       component.hostComponent.searchResult = nonEnhancedArticleRecord;
@@ -820,6 +839,7 @@ describe('ThirdIronButtonsComponent', () => {
 
       expect(getDisplayInfoSpy).toHaveBeenCalled();
       expect(restoreSpy).toHaveBeenCalled();
+      expect(hideWrapperSpy).toHaveBeenCalled();
       expect(component.hasThirdIronSourceItems).toBeFalse();
       expect(component.combinedLinks).toEqual([]);
       expect(component.primoLinks).toEqual([]);
@@ -832,6 +852,10 @@ describe('ThirdIronButtonsComponent', () => {
         await setupNavigationFixture();
       const removeSpy = spyOn(component, 'removePrimoOnlineAvailability').and.returnValue(1);
       const restoreSpy = spyOn(component, 'restorePrimoOnlineAvailability').and.returnValue(1);
+      // Track host-wrapper toggling: non-enhanced render should hide the wrapper,
+      // transitioning to an enhanced record should restore it.
+      const hideWrapperSpy = spyOn(component, 'hideHostWrapper').and.returnValue(true);
+      const restoreWrapperSpy = spyOn(component, 'restoreHostWrapper').and.returnValue(true);
 
       component.hostComponent.searchResult = nonEnhancedArticleRecord;
 
@@ -841,6 +865,7 @@ describe('ThirdIronButtonsComponent', () => {
       fixture.detectChanges();
 
       expect(restoreSpy).toHaveBeenCalled(); // first record not enhanced
+      expect(hideWrapperSpy).toHaveBeenCalled();
       expect(component.hasThirdIronSourceItems).toBeFalse();
 
       component.hostComponent.searchResult = enhancedArticleRecord;
@@ -851,6 +876,7 @@ describe('ThirdIronButtonsComponent', () => {
       expect(getDisplayInfoSpy).toHaveBeenCalled();
       expect(buildCombinedLinksSpy).toHaveBeenCalled();
       expect(removeSpy).toHaveBeenCalled();
+      expect(restoreWrapperSpy).toHaveBeenCalled();
       expect(component.hasThirdIronSourceItems).toBeTrue();
 
       sub?.unsubscribe();

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
@@ -818,8 +818,8 @@ describe('ThirdIronButtonsComponent', () => {
       const { fixture, component, getDisplayInfoSpy } = await setupNavigationFixture();
       const removeSpy = spyOn(component, 'removePrimoOnlineAvailability').and.returnValue(1);
       const restoreSpy = spyOn(component, 'restorePrimoOnlineAvailability').and.returnValue(1);
-      // Track host-wrapper toggling: enhanced render should restore the wrapper, transitioning
-      // to a non-enhanced (empty render) record should collapse it again.
+      // Track host-wrapper toggling: when processing an enhanced record, we should restore the wrapper, transitioning
+      // to a non-enhanced (empty render) record should then hide it again.
       const hideWrapperSpy = spyOn(component, 'hideHostWrapper').and.returnValue(true);
       const restoreWrapperSpy = spyOn(component, 'restoreHostWrapper').and.returnValue(true);
 

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
@@ -182,12 +182,18 @@ export class ThirdIronButtonsComponent {
             this.debugLog.safeSearchEntityMeta(record)
           );
           this.resetEnhancementState();
-          const restoredCount = this.restorePrimoOnlineAvailability(
-            this.elementRef.nativeElement as HTMLElement
-          );
+          const hostElem = this.elementRef.nativeElement as HTMLElement;
+          const restoredCount = this.restorePrimoOnlineAvailability(hostElem);
           this.debugLog.debug('ThirdIronButtons.restorePrimoOnlineAvailability', {
             reason: 'shouldEnhanceButtons=false',
             restoredCount,
+          });
+          // We render nothing in this case; collapse our wrapper so the host flex container's
+          // gap doesn't apply between us and the sibling `nde-online-availability`.
+          const wrapperHidden = this.hideHostWrapper(hostElem);
+          this.debugLog.debug('ThirdIronButtons.hideHostWrapper', {
+            reason: 'shouldEnhanceButtons=false',
+            wrapperHidden,
           });
           return of(null);
         }
@@ -217,12 +223,18 @@ export class ThirdIronButtonsComponent {
 
             if (!this.hasThirdIronSourceItems) {
               this.resetEnhancementState();
-              const restoredCount = this.restorePrimoOnlineAvailability(
-                this.elementRef.nativeElement as HTMLElement
-              );
+              const hostElem = this.elementRef.nativeElement as HTMLElement;
+              const restoredCount = this.restorePrimoOnlineAvailability(hostElem);
               this.debugLog.debug('ThirdIronButtons.restorePrimoOnlineAvailability', {
                 reason: 'hasThirdIronSourceItems=false',
                 restoredCount,
+              });
+              // We render nothing in this case; collapse our wrapper so the host flex container's
+              // gap doesn't apply between us and the sibling `nde-online-availability`.
+              const wrapperHidden = this.hideHostWrapper(hostElem);
+              this.debugLog.debug('ThirdIronButtons.hideHostWrapper', {
+                reason: 'hasThirdIronSourceItems=false',
+                wrapperHidden,
               });
               return displayInfo;
             }
@@ -236,6 +248,13 @@ export class ThirdIronButtonsComponent {
               this.debugLog.debug('ThirdIronButtons.removePrimoOnlineAvailability', {
                 reason: 'hasThirdIronSourceItems',
                 removedCount,
+              });
+              // If a previous emission (for this or another record) had hidden our wrapper because
+              // we were empty, make sure it's visible again now that we have content to render.
+              const wrapperRestored = this.restoreHostWrapper(hostElem);
+              this.debugLog.debug('ThirdIronButtons.restoreHostWrapper', {
+                reason: 'hasThirdIronSourceItems',
+                wrapperRestored,
               });
             }
 
@@ -350,4 +369,51 @@ export class ThirdIronButtonsComponent {
     }
     return 0;
   };
+
+  // The host (Primo NDE) renders this component via `*ngComponentOutlet`, which wraps our
+  // custom element in an `<ng-component>` element. That `<ng-component>` is a direct child
+  // of the host's `.responsive-availability-layout` flex container (which currently sets `gap: .5rem`).
+  //
+  // When this component has nothing to render (no TI buttons), our own host element is empty
+  // (just Angular `<!---->` placeholders), but `<ng-component>` is still a flex item — so the
+  // container's gap is still applied between it and the sibling `<nde-online-availability>`,
+  // leaving an unwanted blank space to the left of the Primo "Available Online" button.
+  //
+  // Hiding our own host element doesn't fix this (the flex item is the wrapper, not us), so
+  // we walk up to the wrapping `<ng-component>` and hide it instead. We mark our mutation
+  // with dataset flags so `restoreHostWrapper` only undoes changes we made.
+  hideHostWrapper = (hostElement: HTMLElement): boolean => {
+    const wrapper = this.findHostWrapper(hostElement);
+    if (!wrapper) return false;
+    if (wrapper.dataset['tiWrapperPrevDisplay'] === undefined) {
+      wrapper.dataset['tiWrapperPrevDisplay'] = wrapper.style.display ?? '';
+    }
+    wrapper.dataset['tiWrapperHiddenByThirdIron'] = '1';
+    wrapper.style.display = 'none';
+    return true;
+  };
+
+  // Restore the wrapping `<ng-component>`'s display if (and only if) we previously hid it.
+  restoreHostWrapper = (hostElement: HTMLElement): boolean => {
+    const wrapper = this.findHostWrapper(hostElement);
+    if (!wrapper) return false;
+    if (wrapper.dataset['tiWrapperHiddenByThirdIron'] !== '1') return false;
+    const prevDisplay = wrapper.dataset['tiWrapperPrevDisplay'];
+    wrapper.style.display = prevDisplay ?? '';
+    delete wrapper.dataset['tiWrapperHiddenByThirdIron'];
+    delete wrapper.dataset['tiWrapperPrevDisplay'];
+    return true;
+  };
+
+  // Walk up a small fixed number of levels from our host element looking for the
+  // `<ng-component>` wrapper. Depth is normally 1, but we allow a few hops in case
+  // a future host inserts an extra wrapper.
+  private findHostWrapper(hostElement: HTMLElement | null): HTMLElement | null {
+    let current: HTMLElement | null = hostElement?.parentElement ?? null;
+    for (let depth = 0; current && depth < 4; depth++) {
+      if (current.tagName.toLowerCase() === 'ng-component') return current;
+      current = current.parentElement;
+    }
+    return null;
+  }
 }

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
@@ -306,11 +306,11 @@ export class ThirdIronButtonsComponent {
       if (onlineAvailabilityElems.length > 0) {
         const arr = Array.from(onlineAvailabilityElems);
         for (const elem of arr) {
-          if (elem.dataset['tiPrevDisplay'] === undefined) {
+          if (elem.dataset['tiOnlineAvailabilityPrevDisplay'] === undefined) {
             // if we need to restore this element later, we will set display back to the original value
-            elem.dataset['tiPrevDisplay'] = elem.style.display ?? '';
+            elem.dataset['tiOnlineAvailabilityPrevDisplay'] = elem.style.display ?? '';
           }
-          elem.dataset['tiHiddenByThirdIron'] = '1';
+          elem.dataset['tiOnlineAvailabilityHiddenByThirdIron'] = '1';
           elem.style.display = 'none';
         }
         return arr.length;
@@ -325,8 +325,8 @@ export class ThirdIronButtonsComponent {
   };
 
   // Traverse the DOM up to 12 levels (arbitrary depth) to find the `nde-online-availability` element and restore it to its original display value.
-  // We only restore elements we previously hid (tiHiddenByThirdIron dataset is set to '1')
-  // After restoring, we delete the tiHiddenByThirdIron and tiPrevDisplay dataset attributes (cleanup).
+  // We only restore elements we previously hid (tiOnlineAvailabilityHiddenByThirdIron dataset is set to '1')
+  // After restoring, we delete the tiOnlineAvailabilityHiddenByThirdIron and tiOnlineAvailabilityPrevDisplay dataset attributes (cleanup).
   restorePrimoOnlineAvailability = (hostElement: HTMLElement): number => {
     let current: HTMLElement | null = hostElement ?? null;
     for (let depth = 0; current && depth < 12; depth++) {
@@ -337,11 +337,11 @@ export class ThirdIronButtonsComponent {
         const arr = Array.from(onlineAvailabilityElems);
         let restored = 0;
         for (const elem of arr) {
-          if (elem.dataset['tiHiddenByThirdIron'] !== '1') continue;
-          const prevDisplay = elem.dataset['tiPrevDisplay'];
+          if (elem.dataset['tiOnlineAvailabilityHiddenByThirdIron'] !== '1') continue;
+          const prevDisplay = elem.dataset['tiOnlineAvailabilityPrevDisplay'];
           elem.style.display = prevDisplay ?? '';
-          delete elem.dataset['tiHiddenByThirdIron'];
-          delete elem.dataset['tiPrevDisplay'];
+          delete elem.dataset['tiOnlineAvailabilityHiddenByThirdIron'];
+          delete elem.dataset['tiOnlineAvailabilityPrevDisplay'];
           restored++;
         }
         return restored;

--- a/src/app/third-iron-module/third-iron-journal-cover/third-iron-journal-cover.component.ts
+++ b/src/app/third-iron-module/third-iron-journal-cover/third-iron-journal-cover.component.ts
@@ -108,10 +108,10 @@ export class ThirdIronJournalCoverComponent {
       | undefined;
     if (!imageElements || imageElements.length === 0) return;
     Array.from(imageElements as HTMLCollectionOf<HTMLElement>).forEach((elem: HTMLElement) => {
-      if (elem.dataset['tiPrevDisplay'] === undefined) {
-        elem.dataset['tiPrevDisplay'] = elem.style.display ?? '';
+      if (elem.dataset['tiRecordImagePrevDisplay'] === undefined) {
+        elem.dataset['tiRecordImagePrevDisplay'] = elem.style.display ?? '';
       }
-      elem.dataset['tiHiddenByThirdIron'] = '1';
+      elem.dataset['tiRecordImageHiddenByThirdIron'] = '1';
       elem.style.display = 'none';
     });
   }
@@ -122,11 +122,11 @@ export class ThirdIronJournalCoverComponent {
       | undefined;
     if (!imageElements || imageElements.length === 0) return;
     Array.from(imageElements as HTMLCollectionOf<HTMLElement>).forEach((elem: HTMLElement) => {
-      if (elem.dataset['tiHiddenByThirdIron'] !== '1') return;
-      const prevDisplay = elem.dataset['tiPrevDisplay'];
+      if (elem.dataset['tiRecordImageHiddenByThirdIron'] !== '1') return;
+      const prevDisplay = elem.dataset['tiRecordImagePrevDisplay'];
       elem.style.display = prevDisplay ?? '';
-      delete elem.dataset['tiHiddenByThirdIron'];
-      delete elem.dataset['tiPrevDisplay'];
+      delete elem.dataset['tiRecordImageHiddenByThirdIron'];
+      delete elem.dataset['tiRecordImagePrevDisplay'];
     });
   }
 }


### PR DESCRIPTION
## Summary - [BZ-10657](https://thirdiron.atlassian.net/browse/BZ-10657)

Fix extra 'gap' style being applied when no TI buttons rendered.

Using a similar pattern here to hide a parent wrapping div that Primo adds to the page if we don't have any Third Iron button content. This will prevent flex gap spacing being added. 

## Deploy Prerequisites


- None

## Deploy Precautions


- None

## Deploy Informational Notes

- None



[BZ-10657]: https://thirdiron.atlassian.net/browse/BZ-10657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted Primo layout/DOM tweaks with reversible dataset-backed hide/show and added unit tests; no auth or data-path changes.
> 
> **Overview**
> Fixes an unwanted horizontal gap next to Primo’s **Available Online** UI when Third Iron renders **no** custom buttons. Primo’s `*ngComponentOutlet` still leaves an empty `<ng-component>` as a flex child in `.responsive-availability-layout`, so the container’s `gap` applies even with no TI content.
> 
> **ThirdIronButtons** now calls **`hideHostWrapper`** / **`restoreHostWrapper`** to set `display: none` on the parent `<ng-component>` (with dataset flags) when enhancement is skipped or there are no TI items, and restores the wrapper when TI buttons are shown again—including when navigating between enhanced and non-enhanced fulldisplay records. Specs assert these calls.
> 
> DOM hide/restore **dataset** keys for `nde-online-availability` and `nde-record-image` are renamed to feature-specific names (`tiOnlineAvailability*`, `tiRecordImage*`) to avoid collisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58fa3dd76d14e75f2fff0f329c2926f5b69d1ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->