### PR TITLE
BZ-10662 More granular (article- and journal-level) link resolver options 

### DIFF
--- a/src/app/services/button-info.service.spec.ts
+++ b/src/app/services/button-info.service.spec.ts
@@ -1877,4 +1877,156 @@ describe('ButtonInfoService', () => {
       expect(link.url).toBe(`/somethingelse/fulldisplay?docid=AAA${fullDisplayHash}`);
     });
   });
+
+  // The newer showLinkResolverLinkOnArticles/showLinkResolverLinkOnJournals elements take
+  // priority over the legacy showLinkResolverLink element when present.
+  describe('link resolver link per entity type', () => {
+    const directLinkViewModel = (): any => ({
+      onlineLinks: [],
+      directLink: 'https://example.com/nde/fulldisplay/some/direct/link',
+      ariaLabel: 'aria',
+    });
+
+    const displayInfoFor = (entityType: EntityType): DisplayWaterfallResponse => ({
+      entityType,
+      mainButtonType: ButtonType.None,
+      mainUrl: '',
+      secondaryUrl: '',
+      showSecondaryButton: false,
+      showBrowzineButton: false,
+      browzineUrl: '',
+    });
+
+    const getDirectLink = (links: any[]) => links.find(l => l.source === 'directLink');
+
+    it('hides the article direct link when showLinkResolverLinkOnArticles is false (overriding legacy true)', async () => {
+      const testBed = await createTestModule({
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: true,
+        showLinkResolverLinkOnArticles: false,
+      });
+      const testService = testBed.inject(ButtonInfoService);
+
+      const result = testService.buildCombinedLinks(
+        displayInfoFor(EntityType.Article),
+        directLinkViewModel()
+      );
+
+      expect(getDirectLink(result)).toBeUndefined();
+    });
+
+    it('shows the article direct link when showLinkResolverLinkOnArticles is true (overriding legacy false)', async () => {
+      const testBed = await createTestModule({
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: false,
+        showLinkResolverLinkOnArticles: true,
+      });
+      const testService = testBed.inject(ButtonInfoService);
+
+      const result = testService.buildCombinedLinks(
+        displayInfoFor(EntityType.Article),
+        directLinkViewModel()
+      );
+
+      expect(getDirectLink(result)).toBeDefined();
+    });
+
+    it('hides the journal direct link when showLinkResolverLinkOnJournals is false (overriding legacy true)', async () => {
+      const testBed = await createTestModule({
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: true,
+        showLinkResolverLinkOnJournals: false,
+      });
+      const testService = testBed.inject(ButtonInfoService);
+
+      const result = testService.buildCombinedLinks(
+        displayInfoFor(EntityType.Journal),
+        directLinkViewModel()
+      );
+
+      expect(getDirectLink(result)).toBeUndefined();
+    });
+
+    it('shows the journal direct link when showLinkResolverLinkOnJournals is true (overriding legacy false)', async () => {
+      const testBed = await createTestModule({
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: false,
+        showLinkResolverLinkOnJournals: true,
+      });
+      const testService = testBed.inject(ButtonInfoService);
+
+      const result = testService.buildCombinedLinks(
+        displayInfoFor(EntityType.Journal),
+        directLinkViewModel()
+      );
+
+      expect(getDirectLink(result)).toBeDefined();
+    });
+
+    it('allows independent control of article vs journal direct links', async () => {
+      const testBed = await createTestModule({
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: true,
+        showLinkResolverLinkOnArticles: false,
+        showLinkResolverLinkOnJournals: true,
+      });
+      const testService = testBed.inject(ButtonInfoService);
+
+      const articleResult = testService.buildCombinedLinks(
+        displayInfoFor(EntityType.Article),
+        directLinkViewModel()
+      );
+      const journalResult = testService.buildCombinedLinks(
+        displayInfoFor(EntityType.Journal),
+        directLinkViewModel()
+      );
+
+      expect(getDirectLink(articleResult)).toBeUndefined();
+      expect(getDirectLink(journalResult)).toBeDefined();
+    });
+
+    it('falls back to legacy showLinkResolverLink when the new elements are absent', async () => {
+      const testBed = await createTestModule({
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: true,
+      });
+      const testService = testBed.inject(ButtonInfoService);
+
+      const articleResult = testService.buildCombinedLinks(
+        displayInfoFor(EntityType.Article),
+        directLinkViewModel()
+      );
+      const journalResult = testService.buildCombinedLinks(
+        displayInfoFor(EntityType.Journal),
+        directLinkViewModel()
+      );
+
+      expect(getDirectLink(articleResult)).toBeDefined();
+      expect(getDirectLink(journalResult)).toBeDefined();
+    });
+
+    it('buildPrimoLinks (NoStack) respects per-entity-type config using the passed entityType', async () => {
+      const testBed = await createTestModule({
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: true,
+        showLinkResolverLinkOnArticles: false,
+        showLinkResolverLinkOnJournals: true,
+      });
+      const testService = testBed.inject(ButtonInfoService);
+
+      const articleResult = testService.buildPrimoLinks(
+        directLinkViewModel(),
+        DEFAULT_PRIMO_LINK_LABELS,
+        EntityType.Article
+      );
+      const journalResult = testService.buildPrimoLinks(
+        directLinkViewModel(),
+        DEFAULT_PRIMO_LINK_LABELS,
+        EntityType.Journal
+      );
+
+      expect(getDirectLink(articleResult)).toBeUndefined();
+      expect(getDirectLink(journalResult)).toBeDefined();
+    });
+  });
 });

--- a/src/app/services/button-info.service.ts
+++ b/src/app/services/button-info.service.ts
@@ -348,11 +348,19 @@ export class ButtonInfoService {
   }
 
   // Wrapper for buildStackOptions to build Primo links
+  // entityType is the type of the host record (article/journal). It is needed so the link
+  // resolver (direct) link can be shown/hidden per entity type even when there is no Third Iron
+  // display info to carry the entity type (the NoStack/Primo-only path).
   buildPrimoLinks = (
     viewModel: PrimoViewModel,
-    labels: PrimoLinkTextBundle = DEFAULT_PRIMO_LINK_LABELS
+    labels: PrimoLinkTextBundle = DEFAULT_PRIMO_LINK_LABELS,
+    entityType: EntityType = EntityType.Unknown
   ): StackLink[] => {
-    return this.buildStackOptions(DEFAULT_DISPLAY_WATERFALL_RESPONSE, viewModel, labels);
+    return this.buildStackOptions(
+      { ...DEFAULT_DISPLAY_WATERFALL_RESPONSE, entityType },
+      viewModel,
+      labels
+    );
   };
 
   // Wrapper for buildStackOptions to build combined Third Iron and Primo links
@@ -382,6 +390,8 @@ export class ButtonInfoService {
       viewOption: this.configService.getViewOption(),
       enableLinkOptimizer: this.configService.enableLinkOptimizer(),
       showLinkResolverLink: this.configService.showLinkResolverLink(),
+      showLinkResolverLinkResolved: this.shouldShowLinkResolverLink(displayInfo.entityType),
+      entityType: displayInfo.entityType,
       hasThirdIronMainButton:
         displayInfo.entityType !== EntityType.Unknown &&
         displayInfo.mainButtonType !== ButtonType.None &&
@@ -438,12 +448,31 @@ export class ButtonInfoService {
     primoOnlineLinks.forEach(link => links.push(link));
 
     // Primo directLink
-    const directLink = this.buildPrimoDirectLinkBase(viewModel, links.length > 0, labels);
+    const directLink = this.buildPrimoDirectLinkBase(
+      viewModel,
+      links.length > 0,
+      labels,
+      displayInfo.entityType
+    );
     if (directLink) {
       links.push(directLink);
     }
 
     return links;
+  }
+
+  // Resolve whether the link resolver (direct) link should be shown for the given entity type.
+  // Article/Journal use their dedicated config elements (which fall back to the legacy element when
+  // unset). Any other/unknown type uses the legacy element directly.
+  private shouldShowLinkResolverLink(entityType: EntityType): boolean {
+    switch (entityType) {
+      case EntityType.Article:
+        return this.configService.showLinkResolverLinkOnArticles();
+      case EntityType.Journal:
+        return this.configService.showLinkResolverLinkOnJournals();
+      default:
+        return this.configService.showLinkResolverLink();
+    }
   }
 
   private buildPrimoOnlineLinksBase(
@@ -479,9 +508,10 @@ export class ButtonInfoService {
   private buildPrimoDirectLinkBase(
     viewModel: PrimoViewModel,
     hasOtherLinks: boolean,
-    labels: PrimoLinkTextBundle = DEFAULT_PRIMO_LINK_LABELS
+    labels: PrimoLinkTextBundle = DEFAULT_PRIMO_LINK_LABELS,
+    entityType: EntityType = EntityType.Unknown
   ): StackLink | null {
-    if (!viewModel.directLink || !this.configService.showLinkResolverLink()) return null;
+    if (!viewModel.directLink || !this.shouldShowLinkResolverLink(entityType)) return null;
 
     const rawDirectLink = (viewModel.directLink ?? '').trim();
     if (!rawDirectLink) return null;

--- a/src/app/services/button-info.service.ts
+++ b/src/app/services/button-info.service.ts
@@ -389,8 +389,8 @@ export class ButtonInfoService {
     this.debugLog.debug('ButtonInfo.buildStackOptions.start', {
       viewOption: this.configService.getViewOption(),
       enableLinkOptimizer: this.configService.enableLinkOptimizer(),
-      showLinkResolverLink: this.configService.showLinkResolverLink(),
-      showLinkResolverLinkResolved: this.shouldShowLinkResolverLink(displayInfo.entityType),
+      showLinkResolverLink: `deprecated: ${this.configService.showLinkResolverLink()}`,
+      shouldShowLinkResolverLink: this.shouldShowLinkResolverLink(displayInfo.entityType),
       entityType: displayInfo.entityType,
       hasThirdIronMainButton:
         displayInfo.entityType !== EntityType.Unknown &&
@@ -462,8 +462,8 @@ export class ButtonInfoService {
   }
 
   // Resolve whether the link resolver (direct) link should be shown for the given entity type.
-  // Article/Journal use their dedicated config elements (which fall back to the legacy element when
-  // unset). Any other/unknown type uses the legacy element directly.
+  // Article/Journal use their dedicated config values (which fall back to the legacy joint value
+  // for either type when unset). Any other/unknown type uses the legacy value directly.
   private shouldShowLinkResolverLink(entityType: EntityType): boolean {
     switch (entityType) {
       case EntityType.Article:

--- a/src/app/services/config.service.spec.ts
+++ b/src/app/services/config.service.spec.ts
@@ -369,6 +369,123 @@ describe('ConfigService', () => {
     });
   });
 
+  describe('showLinkResolverLinkOnArticles', () => {
+    it('should fall back to legacy showLinkResolverLink (true) when not present', () => {
+      // MOCK_MODULE_PARAMETERS sets showLinkResolverLink: true and does not set the new element
+      expect(service.showLinkResolverLinkOnArticles()).toBeTrue();
+    });
+
+    it('should fall back to legacy showLinkResolverLink (false) when not present', async () => {
+      const config = {
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: false,
+      };
+
+      const testBed = await createTestModule(config);
+      const testService = testBed.inject(ConfigService);
+
+      expect(testService.showLinkResolverLinkOnArticles()).toBeFalse();
+    });
+
+    it('should take priority over legacy element when present and true', async () => {
+      const config = {
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: false,
+        showLinkResolverLinkOnArticles: true,
+      };
+
+      const testBed = await createTestModule(config);
+      const testService = testBed.inject(ConfigService);
+
+      expect(testService.showLinkResolverLinkOnArticles()).toBeTrue();
+    });
+
+    it('should take priority over legacy element when present and false', async () => {
+      const config = {
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: true,
+        showLinkResolverLinkOnArticles: false,
+      };
+
+      const testBed = await createTestModule(config);
+      const testService = testBed.inject(ConfigService);
+
+      expect(testService.showLinkResolverLinkOnArticles()).toBeFalse();
+    });
+
+    it('should support string "true"/"false" values', async () => {
+      const config = {
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: 'true',
+        showLinkResolverLinkOnArticles: 'false',
+      };
+
+      const testBed = await createTestModule(config);
+      const testService = testBed.inject(ConfigService);
+
+      expect(testService.showLinkResolverLinkOnArticles()).toBeFalse();
+    });
+  });
+
+  describe('showLinkResolverLinkOnJournals', () => {
+    it('should fall back to legacy showLinkResolverLink (true) when not present', () => {
+      expect(service.showLinkResolverLinkOnJournals()).toBeTrue();
+    });
+
+    it('should fall back to legacy showLinkResolverLink (false) when not present', async () => {
+      const config = {
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: false,
+      };
+
+      const testBed = await createTestModule(config);
+      const testService = testBed.inject(ConfigService);
+
+      expect(testService.showLinkResolverLinkOnJournals()).toBeFalse();
+    });
+
+    it('should take priority over legacy element when present and true', async () => {
+      const config = {
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: false,
+        showLinkResolverLinkOnJournals: true,
+      };
+
+      const testBed = await createTestModule(config);
+      const testService = testBed.inject(ConfigService);
+
+      expect(testService.showLinkResolverLinkOnJournals()).toBeTrue();
+    });
+
+    it('should take priority over legacy element when present and false', async () => {
+      const config = {
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: true,
+        showLinkResolverLinkOnJournals: false,
+      };
+
+      const testBed = await createTestModule(config);
+      const testService = testBed.inject(ConfigService);
+
+      expect(testService.showLinkResolverLinkOnJournals()).toBeFalse();
+    });
+
+    it('should be independent from the article-specific element', async () => {
+      const config = {
+        ...MOCK_MODULE_PARAMETERS,
+        showLinkResolverLink: false,
+        showLinkResolverLinkOnArticles: false,
+        showLinkResolverLinkOnJournals: true,
+      };
+
+      const testBed = await createTestModule(config);
+      const testService = testBed.inject(ConfigService);
+
+      expect(testService.showLinkResolverLinkOnArticles()).toBeFalse();
+      expect(testService.showLinkResolverLinkOnJournals()).toBeTrue();
+    });
+  });
+
   describe('getApiUrl', () => {
     it('should return the correct API URL', () => {
       expect(service.getApiUrl()).toBe('https://public-api.thirdiron.com/public/v1/libraries/222');

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -34,6 +34,13 @@ export class ConfigService {
     }
   }
 
+  // Whether a config element is present (configured) at all, regardless of its value.
+  // Used so newer elements can take priority over legacy ones only when they are actually set.
+  private hasParam(paramName: string): boolean {
+    const value = this.getParam(paramName);
+    return value !== undefined && value !== null;
+  }
+
   getIsUnpaywallEnabled(): boolean {
     return (
       this.getBooleanParam('articlePDFDownloadViaUnpaywallEnabled') ||
@@ -100,6 +107,22 @@ export class ConfigService {
 
   showLinkResolverLink() {
     return this.getBooleanParam('showLinkResolverLink');
+  }
+
+  // The newer `showLinkResolverLinkOnArticles` element TAKES PRIORITY over the legacy
+  // `showLinkResolverLink` when it is present for backwards compatibility.
+  showLinkResolverLinkOnArticles(): boolean {
+    return this.hasParam('showLinkResolverLinkOnArticles')
+      ? this.getBooleanParam('showLinkResolverLinkOnArticles')
+      : this.getBooleanParam('showLinkResolverLink');
+  }
+
+  // The newer `showLinkResolverLinkOnJournals` element TAKES PRIORITY over the legacy
+  // `showLinkResolverLink` when it is present for backwards compatibility.
+  showLinkResolverLinkOnJournals(): boolean {
+    return this.hasParam('showLinkResolverLinkOnJournals')
+      ? this.getBooleanParam('showLinkResolverLinkOnJournals')
+      : this.getBooleanParam('showLinkResolverLink');
   }
 
   enableLinkOptimizer() {

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -109,16 +109,16 @@ export class ConfigService {
     return this.getBooleanParam('showLinkResolverLink');
   }
 
-  // The newer `showLinkResolverLinkOnArticles` element TAKES PRIORITY over the legacy
-  // `showLinkResolverLink` when it is present for backwards compatibility.
+  // The newer `showLinkResolverLinkOnArticles` element TAKES PRIORITY over the legacy `showLinkResolverLink` -
+  // if the newer value is not present, fall back to the legacy value for backwards compatibility.
   showLinkResolverLinkOnArticles(): boolean {
     return this.hasParam('showLinkResolverLinkOnArticles')
       ? this.getBooleanParam('showLinkResolverLinkOnArticles')
       : this.getBooleanParam('showLinkResolverLink');
   }
 
-  // The newer `showLinkResolverLinkOnJournals` element TAKES PRIORITY over the legacy
-  // `showLinkResolverLink` when it is present for backwards compatibility.
+  // The newer `showLinkResolverLinkOnJournals` element TAKES PRIORITY over the legacy `showLinkResolverLink` -
+  // if the newer value is not present, fall back to the legacy value for backwards compatibility.
   showLinkResolverLinkOnJournals(): boolean {
     return this.hasParam('showLinkResolverLinkOnJournals')
       ? this.getBooleanParam('showLinkResolverLinkOnJournals')

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
@@ -268,9 +268,15 @@ export class ThirdIronButtonsComponent {
                 combinedLinks: this.combinedLinks,
               });
             } else {
-              // Build array of Primo only links, filter based on TI config settings
+              // Build array of Primo only links, filter based on TI config settings.
+              // Pass the record's entity type so the link resolver (direct) link can be
+              // shown/hidden per entity type (article vs journal).
               this.combinedLinks = [];
-              this.primoLinks = this.buttonInfoService.buildPrimoLinks(viewModel, primoLinkLabels);
+              this.primoLinks = this.buttonInfoService.buildPrimoLinks(
+                viewModel,
+                primoLinkLabels,
+                displayInfo.entityType
+              );
 
               // Primo links are re-rendered via our own `stacked-dropdown` in NoStack mode.
             }


### PR DESCRIPTION
## Summary - [BZ-10662](https://thirdiron.atlassian.net/browse/BZ-10662)

<!--Required section. The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Introduce more control over whether link resolver buttons should appear

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

This allows libraries to configure the link resolver to either be shown or hidden on either journals or articles.  This is a further improvement beyond what our Primo VE integration does today.

If neither of these are configured, we fall back to the value of the old `showLinkResolverLink` config value.  And if that's not configured, we just use the default behavior.



## Deploy Prerequisites

<!-- Things that must be completed before deployment can safely proceed. Delete any of the items below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Precautions

<!--Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Informational Notes

<!--Things that are not concerns that would hold up a deployment or shape how a deployment is executed, but may be useful to know about when preparing for a deployment or after a deployment is completed. Delete any of the notices below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None



[BZ-10662]: https://thirdiron.atlassian.net/browse/BZ-10662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which online-access links users see on article vs journal records; backward compatible when new config keys are omitted, but misconfiguration could hide or expose resolver links unexpectedly.
> 
> **Overview**
> Adds **article- and journal-specific** module config (`showLinkResolverLinkOnArticles`, `showLinkResolverLinkOnJournals`) so libraries can show or hide the Primo **link resolver / direct link** independently per record type. When those keys are **not** set, behavior still follows legacy `showLinkResolverLink`.
> 
> `ConfigService` gains `hasParam` so the new flags only override the legacy flag when explicitly configured. `ButtonInfoService` routes direct-link visibility through `shouldShowLinkResolverLink(entityType)` (articles/journals use the new getters; unknown types keep the legacy flag). **No-stack** Primo-only stacks now pass `entityType` into `buildPrimoLinks` from `third-iron-buttons` so resolver visibility matches the host record even without Third Iron display info.
> 
> Specs cover config precedence, independent article vs journal control, combined stacks, and No-stack `buildPrimoLinks`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df1f0024361f13eebaa633d4416caf2703dde50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->