### PR TITLE
Change class name to prevent override

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ For runtime troubleshooting, enable debug mode in the browser console (`window._
 
 ## Developer notes
 
+### Pushing commits
+
+When pushing a commit, make sure to change the base repository to the Third Iron develop branch. You'll know its correct when our PR template shows up.
+
 ### Debug mode
 
 This add-on supports a **runtime-toggleable debug mode**. When enabled, the add-on will emit structured log messages to the browser console at key points in the app flow (API calls, decision points, DOM removal, etc.).

--- a/src/app/components/stacked-dropdown/stacked-dropdown.component.html
+++ b/src/app/components/stacked-dropdown/stacked-dropdown.component.html
@@ -1,4 +1,4 @@
-<div class="dropdown-group flex-row flex-layout-center">
+<div class="ti-dropdown-group flex-row flex-layout-center">
   @if (links()[0].source === 'thirdIron') {
     @if (links()[0].mainButtonType === ButtonType.Browzine) {
       <custom-browzine-button

--- a/src/app/third-iron-module/stacked-dropdown-overrides.scss
+++ b/src/app/third-iron-module/stacked-dropdown-overrides.scss
@@ -1,5 +1,5 @@
 // used in stacked-dropdown components to override Angular Material menu/button styles
-.dropdown-group {
+.ti-dropdown-group {
   display: inline-flex;
   position: relative;
 


### PR DESCRIPTION
## Summary - [BZ-10664](https://thirdiron.atlassian.net/browse/BZ-10664)

<!--Required section. The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

A customer reported that one of our buttons is broken when viewing the page in Hebrew which is a RTL language. This PR addresses that.

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

BEFORE:
<img width="1024" height="256" alt="image" src="https://github.com/user-attachments/assets/cf673213-8d7f-4fd8-9343-c739cb425396" />

AFTER:
<img width="1045" height="546" alt="CleanShot 2026-06-29 at 13 01 52" src="https://github.com/user-attachments/assets/0f3eeede-ceaf-4376-8f44-cc520c9800e7" />

<img width="1072" height="483" alt="image" src="https://github.com/user-attachments/assets/8e42b6d9-718a-4d0e-847c-53c077d250a6" />


## Implementation Notes

<!-- Optional: Any file / API changes done to accomplish the larger goal laid out in the summary.-->


1. ​Upon investigating, it seems like in May ExLibris added a style class that broke our drop down, forcing the buttons to be in reverse order, which unintentionally breaks them ( a problem it seems like they were trying to fix).
2. To fix this, I changed the name of our dropdown-group class to ti-dropdown-group to avoid the override that was happening.


## Technical Debt

<!-- Optional: Outline any technical debt along with tradeoffs considered and possible changes for future implementations -->

## Deploy Prerequisites

<!-- Things that must be completed before deployment can safely proceed. Delete any of the items below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Precautions

<!--Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Informational Notes

<!--Things that are not concerns that would hold up a deployment or shape how a deployment is executed, but may be useful to know about when preparing for a deployment or after a deployment is completed. Delete any of the notices below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None



[BZ-10664]: https://thirdiron.atlassian.net/browse/BZ-10664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS/class rename with no auth or data changes; low regression risk aside from verifying stacked dropdown layout in LTR and RTL.
> 
> **Overview**
> **Renames the stacked LibKey dropdown wrapper from `dropdown-group` to `ti-dropdown-group`** in the template and override SCSS so Third Iron styles no longer collide with a generic `.dropdown-group` class Ex Libris added, which was reversing button order and breaking the control in RTL (e.g. Hebrew).
> 
> The README adds a short **Pushing commits** note: set the PR base to the Third Iron `develop` branch so the team PR template appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ab76d20d3ad623c36b1e3f9a4b481bc27ba055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->