### PR TITLE
BZ-10062 fix button loading flash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       day: 'friday'
       time: '08:00'
       timezone: 'US/Central'
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
     assignees:
       - karlbecker
       - danilibros

--- a/src/app/shared/primo-availability-dom.spec.ts
+++ b/src/app/shared/primo-availability-dom.spec.ts
@@ -1,0 +1,212 @@
+import { PrimoAvailabilityDomController } from './primo-availability-dom';
+
+const TAG = PrimoAvailabilityDomController.ONLINE_AVAILABILITY_TAG;
+const HIDDEN_CLASS = PrimoAvailabilityDomController.HIDDEN_CLASS;
+
+// Let any pending MutationObserver callbacks flush.
+const flushMutations = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('PrimoAvailabilityDomController', () => {
+  let controller: PrimoAvailabilityDomController;
+  let container: HTMLElement;
+  let wrapper: HTMLElement;
+  let host: HTMLElement;
+
+  // Build the DOM shape the controller expects in the real app:
+  //   container
+  //     ├─ ng-component (wrapper)        <- our component's wrapper
+  //     │    └─ custom-third-iron-buttons (host, i.e. elementRef.nativeElement)
+  //     └─ nde-online-availability       <- native Primo element (sibling of the wrapper)
+  // The availability element is only appended when `withAvailability` is true, so tests can also
+  // exercise the "not rendered yet" path.
+  const buildDom = (withAvailability = true): HTMLElement | null => {
+    container = document.createElement('div');
+    wrapper = document.createElement('ng-component');
+    host = document.createElement('custom-third-iron-buttons');
+    wrapper.appendChild(host);
+    container.appendChild(wrapper);
+
+    let availability: HTMLElement | null = null;
+    if (withAvailability) {
+      availability = document.createElement(TAG);
+      container.appendChild(availability);
+    }
+    document.body.appendChild(container);
+    return availability;
+  };
+
+  beforeEach(() => {
+    controller = new PrimoAvailabilityDomController();
+  });
+
+  afterEach(() => {
+    controller.disconnect();
+    if (container?.parentElement) {
+      container.parentElement.removeChild(container);
+    }
+  });
+
+  describe('hideAvailability', () => {
+    it('hides the native element found by walking up from the host, and returns the count', () => {
+      const availability = buildDom()!;
+
+      const count = controller.hideAvailability(host);
+
+      expect(count).toBe(1);
+      expect(availability.classList.contains(HIDDEN_CLASS)).toBeTrue();
+      expect(availability.style.display).toBe('none');
+      expect(availability.dataset['tiOnlineAvailabilityHiddenByThirdIron']).toBe('1');
+    });
+
+    it('remembers the previous inline display value so it can be restored exactly', () => {
+      const availability = buildDom()!;
+      availability.style.display = 'flex';
+
+      controller.hideAvailability(host);
+
+      expect(availability.dataset['tiOnlineAvailabilityPrevDisplay']).toBe('flex');
+      expect(availability.style.display).toBe('none');
+    });
+
+    it('returns 0 when there is no native element to hide', () => {
+      buildDom(false);
+      expect(controller.hideAvailability(host)).toBe(0);
+    });
+
+    it('returns 0 for a null host', () => {
+      expect(controller.hideAvailability(null)).toBe(0);
+    });
+  });
+
+  describe('restoreAvailability', () => {
+    it('restores the previous display, removes the class + dataset flags, and returns the count', () => {
+      const availability = buildDom()!;
+      availability.style.display = 'flex';
+      controller.hideAvailability(host);
+
+      const restored = controller.restoreAvailability(host);
+
+      expect(restored).toBe(1);
+      expect(availability.classList.contains(HIDDEN_CLASS)).toBeFalse();
+      expect(availability.style.display).toBe('flex');
+      expect(availability.dataset['tiOnlineAvailabilityHiddenByThirdIron']).toBeUndefined();
+      expect(availability.dataset['tiOnlineAvailabilityPrevDisplay']).toBeUndefined();
+    });
+
+    it('does not touch elements it did not hide', () => {
+      const availability = buildDom()!;
+      availability.style.display = 'block';
+
+      const restored = controller.restoreAvailability(host);
+
+      expect(restored).toBe(0);
+      expect(availability.style.display).toBe('block');
+    });
+  });
+
+  describe('hideWrapper / restoreWrapper', () => {
+    it('hides the ng-component wrapper and restores it exactly', () => {
+      buildDom();
+      wrapper.style.display = 'inline-block';
+
+      expect(controller.hideWrapper(host)).toBeTrue();
+      expect(wrapper.style.display).toBe('none');
+      expect(wrapper.dataset['tiWrapperHiddenByThirdIron']).toBe('1');
+
+      expect(controller.restoreWrapper(host)).toBeTrue();
+      expect(wrapper.style.display).toBe('inline-block');
+      expect(wrapper.dataset['tiWrapperHiddenByThirdIron']).toBeUndefined();
+    });
+
+    it('returns false when there is no ng-component wrapper', () => {
+      // host directly under container, no ng-component ancestor
+      container = document.createElement('div');
+      host = document.createElement('custom-third-iron-buttons');
+      container.appendChild(host);
+      document.body.appendChild(container);
+
+      expect(controller.hideWrapper(host)).toBeFalse();
+      expect(controller.restoreWrapper(host)).toBeFalse();
+    });
+
+    it('restoreWrapper is a no-op when the wrapper was not hidden by us', () => {
+      buildDom();
+      expect(controller.restoreWrapper(host)).toBeFalse();
+    });
+  });
+
+  describe('observeAvailability', () => {
+    it('hides a native element that appears AFTER we start observing (the core race)', async () => {
+      buildDom(false); // native element not rendered yet
+      controller.observeAvailability(host);
+
+      // Primo renders the native element later.
+      const availability = document.createElement(TAG);
+      container.appendChild(availability);
+      await flushMutations();
+
+      expect(availability.classList.contains(HIDDEN_CLASS)).toBeTrue();
+      expect(availability.style.display).toBe('none');
+    });
+
+    it('hides an element that is already present when observing starts', () => {
+      const availability = buildDom()!;
+      controller.observeAvailability(host);
+
+      // Synchronous initial pass hides what's already there (no mutation needed).
+      expect(availability.classList.contains(HIDDEN_CLASS)).toBeTrue();
+    });
+
+    it('re-hides an element that Primo replaces (re-render)', async () => {
+      const first = buildDom()!;
+      controller.observeAvailability(host);
+      expect(first.classList.contains(HIDDEN_CLASS)).toBeTrue();
+
+      // Primo removes and re-adds a fresh (unhidden) element.
+      container.removeChild(first);
+      const replacement = document.createElement(TAG);
+      container.appendChild(replacement);
+      await flushMutations();
+
+      expect(replacement.classList.contains(HIDDEN_CLASS)).toBeTrue();
+    });
+
+    it('stops re-hiding when the shouldKeepHiding guard returns false', async () => {
+      let guarding = true;
+      buildDom(false);
+      controller.observeAvailability(host, () => guarding);
+
+      guarding = false;
+      const availability = document.createElement(TAG);
+      container.appendChild(availability);
+      await flushMutations();
+
+      expect(availability.classList.contains(HIDDEN_CLASS)).toBeFalse();
+    });
+
+    it('does not hide new elements after disconnect()', async () => {
+      buildDom(false);
+      controller.observeAvailability(host);
+      controller.disconnect();
+
+      const availability = document.createElement(TAG);
+      container.appendChild(availability);
+      await flushMutations();
+
+      expect(availability.classList.contains(HIDDEN_CLASS)).toBeFalse();
+    });
+  });
+
+  describe('isObserving', () => {
+    it('reflects the observer lifecycle', () => {
+      buildDom();
+      expect(controller.isObserving()).toBeFalse();
+
+      controller.observeAvailability(host);
+      expect(controller.isObserving()).toBeTrue();
+
+      controller.disconnect();
+      expect(controller.isObserving()).toBeFalse();
+    });
+  });
+});

--- a/src/app/shared/primo-availability-dom.ts
+++ b/src/app/shared/primo-availability-dom.ts
@@ -1,15 +1,20 @@
+import { Injectable } from '@angular/core';
+
 /**
- * Framework-agnostic DOM helper for coordinating with the host Primo (NDE) online-availability UI.
+ * DOM helper for coordinating with the host Primo (NDE) online-availability UI.
  *
- * The ThirdIron buttons component is injected *before* the host `nde-online-availability` element
+ * The ThirdIron buttons component is inserted in the DOM *before* the host `nde-online-availability` element
  * (via `nde-online-availability-before`). When we enhance a record we need to hide that native
  * element (so we don't show duplicate buttons), and when we don't enhance we must leave it alone /
  * restore it. This controller owns all of that DOM plumbing so the component can stay focused on
  * the enhancement/rendering logic.
  *
- * It has no Angular or RxJS dependencies and keeps its only piece of state (a MutationObserver)
- * internal, which makes it straightforward to unit test in isolation.
+ * Aside from the `@Injectable()` decorator it has no Angular/RxJS dependencies, and it keeps its
+ * only piece of state (a MutationObserver) internal — which makes it straightforward to unit test
+ * in isolation. It is provided at the *component* level (not root) so each buttons component gets
+ * its own instance and therefore its own observer.
  */
+@Injectable()
 export class PrimoAvailabilityDomController {
   static readonly ONLINE_AVAILABILITY_TAG = 'nde-online-availability';
 
@@ -161,8 +166,8 @@ export class PrimoAvailabilityDomController {
     let current: HTMLElement | null = hostElement?.parentElement ?? null;
     for (let depth = 0; current && depth < 12; depth++) {
       if (
-        current.getElementsByTagName(PrimoAvailabilityDomController.ONLINE_AVAILABILITY_TAG).length >
-        0
+        current.getElementsByTagName(PrimoAvailabilityDomController.ONLINE_AVAILABILITY_TAG)
+          .length > 0
       ) {
         return current;
       }

--- a/src/app/shared/primo-availability-dom.ts
+++ b/src/app/shared/primo-availability-dom.ts
@@ -1,0 +1,195 @@
+/**
+ * Framework-agnostic DOM helper for coordinating with the host Primo (NDE) online-availability UI.
+ *
+ * The ThirdIron buttons component is injected *before* the host `nde-online-availability` element
+ * (via `nde-online-availability-before`). When we enhance a record we need to hide that native
+ * element (so we don't show duplicate buttons), and when we don't enhance we must leave it alone /
+ * restore it. This controller owns all of that DOM plumbing so the component can stay focused on
+ * the enhancement/rendering logic.
+ *
+ * It has no Angular or RxJS dependencies and keeps its only piece of state (a MutationObserver)
+ * internal, which makes it straightforward to unit test in isolation.
+ */
+export class PrimoAvailabilityDomController {
+  static readonly ONLINE_AVAILABILITY_TAG = 'nde-online-availability';
+
+  // CSS class used to hide the native availability element. Marked `!important` in the ThirdIron
+  // buttons component stylesheet so Primo's own inline / bound `display` styles can't override us.
+  // NOTE: the same literal is referenced in third-iron-buttons.component.scss.
+  static readonly HIDDEN_CLASS = 'ti-online-availability-hidden';
+
+  private observer: MutationObserver | null = null;
+
+  /**
+   * Hide the native `nde-online-availability` element(s). Walks up the DOM from `hostElement` until
+   * it finds an ancestor that contains the element, then hides all matches. Returns how many were
+   * hidden (0 if not found — e.g. Primo hasn't rendered it yet; use observeAvailability for that).
+   * Depth of 12 is arbitrary but a reasonable ceiling.
+   */
+  hideAvailability = (hostElement: HTMLElement | null): number => {
+    let current: HTMLElement | null = hostElement ?? null;
+    for (let depth = 0; current && depth < 12; depth++) {
+      const elems = current.getElementsByTagName(
+        PrimoAvailabilityDomController.ONLINE_AVAILABILITY_TAG
+      ) as HTMLCollectionOf<HTMLElement>;
+      if (elems.length > 0) {
+        const arr = Array.from(elems);
+        for (const elem of arr) {
+          this.hideElement(elem);
+        }
+        return arr.length;
+      }
+      current = current.parentElement;
+    }
+    return 0;
+  };
+
+  /**
+   * Restore any `nde-online-availability` element(s) we previously hid, back to their original
+   * inline display value. Only touches elements we marked, and cleans up our dataset flags.
+   */
+  restoreAvailability = (hostElement: HTMLElement | null): number => {
+    let current: HTMLElement | null = hostElement ?? null;
+    for (let depth = 0; current && depth < 12; depth++) {
+      const elems = current.getElementsByTagName(
+        PrimoAvailabilityDomController.ONLINE_AVAILABILITY_TAG
+      ) as HTMLCollectionOf<HTMLElement>;
+      if (elems.length > 0) {
+        const arr = Array.from(elems);
+        let restored = 0;
+        for (const elem of arr) {
+          if (elem.dataset['tiOnlineAvailabilityHiddenByThirdIron'] !== '1') continue;
+          const prevDisplay = elem.dataset['tiOnlineAvailabilityPrevDisplay'];
+          elem.classList.remove(PrimoAvailabilityDomController.HIDDEN_CLASS);
+          elem.style.display = prevDisplay ?? '';
+          delete elem.dataset['tiOnlineAvailabilityHiddenByThirdIron'];
+          delete elem.dataset['tiOnlineAvailabilityPrevDisplay'];
+          restored++;
+        }
+        return restored;
+      }
+      current = current.parentElement;
+    }
+    return 0;
+  };
+
+  /**
+   * Watch the surrounding container so the native availability element stays hidden even if Primo
+   * renders (or re-renders) it *after* our initial one-shot hide — the common race, since we're
+   * injected before it. Safe to call repeatedly; resets any previous observer.
+   *
+   * @param shouldKeepHiding optional guard; when it returns false the observer stops re-hiding
+   *        (belt-and-suspenders — callers should still `disconnect()` before restoring).
+   */
+  observeAvailability = (
+    hostElement: HTMLElement | null,
+    shouldKeepHiding?: () => boolean
+  ): void => {
+    this.disconnect();
+    if (typeof MutationObserver === 'undefined') return;
+
+    const root = this.getObserverRoot(hostElement);
+    if (!root) return;
+
+    // Hide anything already present, then watch for future additions / re-renders.
+    this.hideWithin(root);
+
+    this.observer = new MutationObserver(() => {
+      if (shouldKeepHiding && !shouldKeepHiding()) return;
+      this.hideWithin(root);
+    });
+    this.observer.observe(root, { childList: true, subtree: true });
+  };
+
+  disconnect = (): void => {
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+  };
+
+  isObserving = (): boolean => this.observer !== null;
+
+  /**
+   * The host renders this component via `*ngComponentOutlet`, wrapping our element in an
+   * `<ng-component>` that is a flex item of the host's `.responsive-availability-layout` container.
+   * When we render nothing, that empty wrapper still triggers the container's `gap`, leaving a blank
+   * space to the left of the Primo button. Hiding our own element doesn't help (the flex item is the
+   * wrapper), so we hide the wrapper instead, marking it so restoreWrapper only undoes our change.
+   */
+  hideWrapper = (hostElement: HTMLElement | null): boolean => {
+    const wrapper = this.findWrapper(hostElement);
+    if (!wrapper) return false;
+    if (wrapper.dataset['tiWrapperPrevDisplay'] === undefined) {
+      wrapper.dataset['tiWrapperPrevDisplay'] = wrapper.style.display ?? '';
+    }
+    wrapper.dataset['tiWrapperHiddenByThirdIron'] = '1';
+    wrapper.style.display = 'none';
+    return true;
+  };
+
+  // Restore the wrapping `<ng-component>`'s display if (and only if) we previously hid it.
+  restoreWrapper = (hostElement: HTMLElement | null): boolean => {
+    const wrapper = this.findWrapper(hostElement);
+    if (!wrapper) return false;
+    if (wrapper.dataset['tiWrapperHiddenByThirdIron'] !== '1') return false;
+    const prevDisplay = wrapper.dataset['tiWrapperPrevDisplay'];
+    wrapper.style.display = prevDisplay ?? '';
+    delete wrapper.dataset['tiWrapperHiddenByThirdIron'];
+    delete wrapper.dataset['tiWrapperPrevDisplay'];
+    return true;
+  };
+
+  // Hide a single element via a CSS class (with `!important`) plus an inline style, remembering the
+  // previous inline display value so restoreAvailability() can put it back exactly.
+  private hideElement(elem: HTMLElement): void {
+    if (elem.dataset['tiOnlineAvailabilityPrevDisplay'] === undefined) {
+      elem.dataset['tiOnlineAvailabilityPrevDisplay'] = elem.style.display ?? '';
+    }
+    elem.dataset['tiOnlineAvailabilityHiddenByThirdIron'] = '1';
+    elem.classList.add(PrimoAvailabilityDomController.HIDDEN_CLASS);
+    elem.style.display = 'none';
+  }
+
+  // Pick the container to watch. The native element is a sibling of our wrapping `<ng-component>`,
+  // so that wrapper's parent is the natural (tightly scoped) root. Falls back to the nearest
+  // ancestor already containing the element, then to our own parent.
+  private getObserverRoot(hostElement: HTMLElement | null): HTMLElement | null {
+    const wrapperParent = this.findWrapper(hostElement)?.parentElement ?? null;
+    if (wrapperParent) return wrapperParent;
+
+    let current: HTMLElement | null = hostElement?.parentElement ?? null;
+    for (let depth = 0; current && depth < 12; depth++) {
+      if (
+        current.getElementsByTagName(PrimoAvailabilityDomController.ONLINE_AVAILABILITY_TAG).length >
+        0
+      ) {
+        return current;
+      }
+      current = current.parentElement;
+    }
+    return hostElement?.parentElement ?? null;
+  }
+
+  // Hide every `nde-online-availability` element currently within `root` (idempotent).
+  private hideWithin(root: HTMLElement): number {
+    const elems = Array.from(
+      root.getElementsByTagName(PrimoAvailabilityDomController.ONLINE_AVAILABILITY_TAG)
+    ) as HTMLElement[];
+    for (const elem of elems) {
+      this.hideElement(elem);
+    }
+    return elems.length;
+  }
+
+  // Walk up a small fixed number of levels looking for the `<ng-component>` wrapper. Depth is
+  // normally 1, but we allow a few hops in case a future host inserts an extra wrapper.
+  private findWrapper(hostElement: HTMLElement | null): HTMLElement | null {
+    let current: HTMLElement | null = hostElement?.parentElement ?? null;
+    for (let depth = 0; current && depth < 4; depth++) {
+      if (current.tagName.toLowerCase() === 'ng-component') return current;
+      current = current.parentElement;
+    }
+    return null;
+  }
+}

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.html
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.html
@@ -1,57 +1,77 @@
-@if (viewModel$ | async; as viewModel) {
-  @if (displayInfo$ | async; as displayInfo) {
-    @if (hasThirdIronSourceItems) {
-      @if (viewOption !== ViewOptionType.NoStack && combinedLinks.length > 0) {
-        <!-- dealing with stack options -->
-        <div class="ti-stack-options-container">
-          <stacked-dropdown [links]="combinedLinks"></stacked-dropdown>
-          @if (
-            viewOption === ViewOptionType.StackPlusBrowzine &&
-            displayInfo.showBrowzineButton &&
-            displayInfo.browzineUrl
-          ) {
-            <!-- for Stack + Browzine view option -->
-            <custom-browzine-button
-              class="ti-browzine-button-with-stack"
-              [entityType]="displayInfo.entityType"
-              [url]="displayInfo.browzineUrl"
-            ></custom-browzine-button>
-          }
-          @if (viewModel.consolidatedCoverage) {
-            <div class="ti-consolidated-coverage">
-              {{ viewModel.consolidatedCoverage }}
-            </div>
-          }
-        </div>
-      } @else {
-        <!-- dealing with individual button options -->
-        <span class="ti-no-stack-container">
-          @if (displayInfo.mainUrl !== '') {
-            <main-button
-              class="ti-single-button"
-              [url]="displayInfo.mainUrl"
-              [buttonType]="displayInfo.mainButtonType"
-            ></main-button>
-          }
-          @if (displayInfo.showSecondaryButton && displayInfo.secondaryUrl) {
-            <article-link-button class="ti-single-button" [url]="displayInfo.secondaryUrl || ''"></article-link-button>
-          }
-          @if (primoLinks.length > 0) {
-            <stacked-dropdown [links]="primoLinks"></stacked-dropdown>
-          }
-          @if (displayInfo.showBrowzineButton && displayInfo.browzineUrl) {
-            <custom-browzine-button
-              class="ti-single-button"
-              [entityType]="displayInfo.entityType"
-              [url]="displayInfo.browzineUrl"
-            ></custom-browzine-button>
-          }
-          @if (viewModel.consolidatedCoverage) {
-            <div class="ti-consolidated-coverage">
-              {{ viewModel.consolidatedCoverage }}
-            </div>
-          }
-        </span>
+@if (buttonsPhase === 'loading') {
+  <!--
+    Loading placeholder shown in place of the native Primo buttons (which we hide eagerly) while the
+    LibKey call is in-flight. The container always reserves space to avoid layout shift; the shimmer
+    itself only becomes visible once the skeleton-delay has elapsed (showSkeleton), so fast/cached
+    responses don't flash a placeholder. aria-hidden/aria-busy keep it out of the accessibility tree.
+  -->
+  <span
+    class="ti-buttons-skeleton"
+    [class.is-visible]="showSkeleton"
+    aria-hidden="true"
+    aria-busy="true"
+  >
+    <span class="ti-skeleton-chip"></span>
+    <span class="ti-skeleton-chip"></span>
+  </span>
+}
+
+@if (buttonsPhase === 'enhanced') {
+  @if (viewModel$ | async; as viewModel) {
+    @if (displayInfo$ | async; as displayInfo) {
+      @if (hasThirdIronSourceItems) {
+        @if (viewOption !== ViewOptionType.NoStack && combinedLinks.length > 0) {
+          <!-- dealing with stack options -->
+          <div class="ti-stack-options-container">
+            <stacked-dropdown [links]="combinedLinks"></stacked-dropdown>
+            @if (
+              viewOption === ViewOptionType.StackPlusBrowzine &&
+              displayInfo.showBrowzineButton &&
+              displayInfo.browzineUrl
+            ) {
+              <!-- for Stack + Browzine view option -->
+              <custom-browzine-button
+                class="ti-browzine-button-with-stack"
+                [entityType]="displayInfo.entityType"
+                [url]="displayInfo.browzineUrl"
+              ></custom-browzine-button>
+            }
+            @if (viewModel.consolidatedCoverage) {
+              <div class="ti-consolidated-coverage">
+                {{ viewModel.consolidatedCoverage }}
+              </div>
+            }
+          </div>
+        } @else {
+          <!-- dealing with individual button options -->
+          <span class="ti-no-stack-container">
+            @if (displayInfo.mainUrl !== '') {
+              <main-button
+                class="ti-single-button"
+                [url]="displayInfo.mainUrl"
+                [buttonType]="displayInfo.mainButtonType"
+              ></main-button>
+            }
+            @if (displayInfo.showSecondaryButton && displayInfo.secondaryUrl) {
+              <article-link-button class="ti-single-button" [url]="displayInfo.secondaryUrl || ''"></article-link-button>
+            }
+            @if (primoLinks.length > 0) {
+              <stacked-dropdown [links]="primoLinks"></stacked-dropdown>
+            }
+            @if (displayInfo.showBrowzineButton && displayInfo.browzineUrl) {
+              <custom-browzine-button
+                class="ti-single-button"
+                [entityType]="displayInfo.entityType"
+                [url]="displayInfo.browzineUrl"
+              ></custom-browzine-button>
+            }
+            @if (viewModel.consolidatedCoverage) {
+              <div class="ti-consolidated-coverage">
+                {{ viewModel.consolidatedCoverage }}
+              </div>
+            }
+          </span>
+        }
       }
     }
   }

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.scss
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.scss
@@ -1,3 +1,10 @@
+// Hide the native Primo `nde-online-availability` while we're enhancing a record. Uses `!important`
+// so it beats Primo's own inline / bound `display` styles, and so the native buttons can't flash in
+// between our JS toggles. Applied/removed via ThirdIronButtonsComponent (class + MutationObserver).
+nde-online-availability.ti-online-availability-hidden {
+  display: none !important;
+}
+
 .ti-single-button {
   float: left;
 }

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.scss
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.scss
@@ -25,3 +25,61 @@
   color: var(--sys-primary);
   font-weight: 400;
 }
+
+// Loading placeholder shown while the LibKey call is in-flight (see component template).
+// The container reserves space at all times to avoid layout shift; the chips only become
+// visible (and shimmer) once `.is-visible` is applied, so fast responses don't flash a placeholder.
+.ti-buttons-skeleton {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 5px;
+  min-height: 36px; // roughly matches the height of a rendered button row to keep layout stable
+}
+
+.ti-skeleton-chip {
+  display: inline-block;
+  height: 32px;
+  width: 96px;
+  border-radius: 18px;
+  background: var(--sys-surface-variant, rgba(0, 0, 0, 0.08));
+  // Hidden-but-space-reserving until the skeleton-delay elapses.
+  visibility: hidden;
+  opacity: 0;
+
+  &:nth-child(2) {
+    width: 72px;
+  }
+}
+
+.ti-buttons-skeleton.is-visible .ti-skeleton-chip {
+  visibility: visible;
+  opacity: 1;
+  background: linear-gradient(
+    90deg,
+    var(--sys-surface-variant, rgba(0, 0, 0, 0.08)) 25%,
+    var(--sys-surface, rgba(0, 0, 0, 0.04)) 37%,
+    var(--sys-surface-variant, rgba(0, 0, 0, 0.08)) 63%
+  );
+  background-size: 400% 100%;
+  animation: ti-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes ti-skeleton-shimmer {
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
+  }
+}
+
+// Respect reduced-motion: show a static muted chip rather than an animated shimmer.
+@media (prefers-reduced-motion: reduce) {
+  .ti-buttons-skeleton.is-visible .ti-skeleton-chip {
+    animation: none;
+    background: var(--sys-surface-variant, rgba(0, 0, 0, 0.08));
+  }
+}

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
@@ -1,5 +1,5 @@
-import { TestBed } from '@angular/core/testing';
-import { BehaviorSubject, of } from 'rxjs';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { BehaviorSubject, Subject, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 import { Component, Input } from '@angular/core';
@@ -165,6 +165,10 @@ describe('ThirdIronButtonsComponent', () => {
       component.combinedLinks = opts?.combinedLinks ?? [];
       component.primoLinks = opts?.primoLinks ?? [];
       component.hasThirdIronSourceItems = opts?.hasThirdIronSourceItems ?? true;
+      // The template only renders our buttons in the 'enhanced' phase. These tests exercise the
+      // rendered markup directly, so force the phase here (the real phase transitions are covered
+      // separately in the anti-flash loading-state tests).
+      component.buttonsPhase = 'enhanced';
 
       // First pass runs the component's ngOnInit, which overwrites `displayInfo$` with the enhance pipeline.
       // We then replace the streams with our test values (we're testing template branching, not ngOnInit).
@@ -878,6 +882,161 @@ describe('ThirdIronButtonsComponent', () => {
 
       sub?.unsubscribe();
     });
+  });
+
+  // Anti-flash loading behavior: we hide the native Primo buttons eagerly (before the LibKey call
+  // resolves) and show a loading skeleton, guarded by a skeleton-delay, a min-visible time, and a
+  // max-wait fallback. These tests drive the real pipeline with a controllable displayInfo source.
+  describe('anti-flash loading state', () => {
+    const enhancedArticleRecord = {
+      pnx: {
+        control: { recordid: ['rec-enhanced'] },
+        display: { type: ['article'] },
+        addata: { doi: ['10.1000/enhanced'] },
+      },
+    };
+
+    const enhancedDisplayInfo = {
+      entityType: EntityType.Article,
+      mainButtonType: ButtonType.DirectToPDF,
+      mainUrl: 'https://example.com/pdf',
+      showSecondaryButton: false,
+      secondaryUrl: '',
+      showBrowzineButton: false,
+      browzineUrl: '',
+    };
+
+    const emptyDisplayInfo = {
+      entityType: EntityType.Unknown,
+      mainButtonType: ButtonType.None,
+      mainUrl: '',
+      showSecondaryButton: false,
+      secondaryUrl: '',
+      showBrowzineButton: false,
+      browzineUrl: '',
+    };
+
+    let displayInfoSubject: Subject<any>;
+    let fixture: ReturnType<typeof TestBed.createComponent<ThirdIronButtonsComponent>>;
+    let component: ThirdIronButtonsComponent;
+    let removeSpy: jasmine.Spy;
+    let restoreSpy: jasmine.Spy;
+
+    beforeEach(async () => {
+      displayInfoSubject = new Subject<any>();
+
+      await TestBed.resetTestingModule()
+        .configureTestingModule({
+          imports: [ThirdIronButtonsComponent],
+          providers: [
+            ConfigService,
+            { provide: Store, useValue: mockStore },
+            { provide: 'MODULE_PARAMETERS', useValue: MOCK_MODULE_PARAMETERS },
+            { provide: TranslateService, useValue: { stream: (key: string) => of(key) } },
+            { provide: SearchEntityService, useValue: { shouldEnhanceButtons: () => true } },
+            {
+              provide: ButtonInfoService,
+              useValue: {
+                getDisplayInfo: () => displayInfoSubject.asObservable(),
+                buildCombinedLinks: () => [],
+                buildPrimoLinks: () => [],
+              },
+            },
+            {
+              provide: DebugLogService,
+              useValue: { debug: () => {}, warn: () => {}, safeSearchEntityMeta: () => ({}) },
+            },
+          ],
+        })
+        .overrideComponent(ThirdIronButtonsComponent, {
+          set: {
+            imports: [
+              AsyncPipe,
+              StackedDropdownStubComponent,
+              MainButtonStubComponent,
+              ArticleLinkButtonStubComponent,
+              BrowzineButtonStubComponent,
+            ],
+          },
+        })
+        .compileComponents();
+
+      fixture = TestBed.createComponent(ThirdIronButtonsComponent);
+      component = fixture.componentInstance;
+      component.viewOption = ViewOptionType.StackPlusBrowzine;
+      removeSpy = spyOn(component, 'removePrimoOnlineAvailability').and.returnValue(1);
+      restoreSpy = spyOn(component, 'restorePrimoOnlineAvailability').and.returnValue(1);
+      spyOn(component, 'restoreHostWrapper').and.returnValue(true);
+      spyOn(component, 'hideHostWrapper').and.returnValue(true);
+      component.hostComponent = {
+        searchResult: enhancedArticleRecord,
+        viewModel$: of({ onlineLinks: [], directLink: '', ariaLabel: '' }),
+      };
+    });
+
+    it('eagerly hides native Primo buttons and shows a loading skeleton before the call resolves', fakeAsync(() => {
+      fixture.detectChanges(); // ngOnInit subscribes to + drives the pipeline
+
+      // Native buttons hidden immediately; loading phase entered; shimmer not shown yet.
+      expect(component.buttonsPhase).toBe('loading');
+      expect(removeSpy).toHaveBeenCalled();
+      expect(component.showSkeleton).toBeFalse();
+
+      // Shimmer only appears after the skeleton-delay elapses.
+      tick(component['SKELETON_DELAY_MS']);
+      expect(component.showSkeleton).toBeTrue();
+
+      // Resolving with TI content transitions to 'enhanced' (after the min-visible window).
+      displayInfoSubject.next(enhancedDisplayInfo);
+      tick(component['SKELETON_MIN_VISIBLE_MS']);
+
+      expect(component.buttonsPhase).toBe('enhanced');
+      expect(component.showSkeleton).toBeFalse();
+
+      fixture.destroy();
+    }));
+
+    it('does not flash a skeleton for fast responses (resolves before the skeleton delay)', fakeAsync(() => {
+      fixture.detectChanges();
+      expect(component.buttonsPhase).toBe('loading');
+
+      // Resolve well before the skeleton-delay.
+      tick(50);
+      displayInfoSubject.next(enhancedDisplayInfo);
+
+      expect(component.showSkeleton).toBeFalse();
+      expect(component.buttonsPhase).toBe('enhanced');
+
+      // The skeleton timer must not fire after the fact.
+      tick(component['SKELETON_DELAY_MS']);
+      expect(component.showSkeleton).toBeFalse();
+
+      fixture.destroy();
+    }));
+
+    it('restores native Primo buttons via the max-wait fallback if the call never settles', fakeAsync(() => {
+      fixture.detectChanges();
+      expect(component.buttonsPhase).toBe('loading');
+
+      tick(component['MAX_WAIT_MS']);
+
+      expect(component.buttonsPhase).toBe('passthrough');
+      expect(restoreSpy).toHaveBeenCalled();
+
+      fixture.destroy();
+    }));
+
+    it('restores native Primo buttons when the settled result has no Third Iron content', fakeAsync(() => {
+      fixture.detectChanges();
+
+      displayInfoSubject.next(emptyDisplayInfo);
+
+      expect(component.hasThirdIronSourceItems).toBeFalse();
+      expect(component.buttonsPhase).toBe('passthrough');
+      expect(restoreSpy).toHaveBeenCalled();
+
+      fixture.destroy();
+    }));
   });
 
   it('passes translated Primo labels into buildPrimoLinks and updates when translation streams emit', async () => {

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
@@ -284,10 +284,10 @@ describe('ThirdIronButtonsComponent', () => {
         };
 
         // Spy on side-effect method to ensure enhancement pipeline didn't run.
-        spyOn(component, 'removePrimoOnlineAvailability').and.callThrough();
+        spyOn(component.availabilityDom, 'hideAvailability').and.callThrough();
         // Spy on host-wrapper toggling so tests can assert we collapse the wrapping
         // `<ng-component>` to avoid the host flex container's `gap` rule applying.
-        spyOn(component, 'hideHostWrapper').and.callThrough();
+        spyOn(component.availabilityDom, 'hideWrapper').and.callThrough();
 
         fixture.detectChanges(); // runs ngOnInit
         // Ensure the Rx pipeline runs by subscribing (in the real app the template async pipe does this).
@@ -314,7 +314,7 @@ describe('ThirdIronButtonsComponent', () => {
       it('renders nothing and does not remove original Primo online availability element', async () => {
         const { component, el, sub } = await setupSkipEnhancement();
 
-        expect(component.removePrimoOnlineAvailability).not.toHaveBeenCalled();
+        expect(component.availabilityDom.hideAvailability).not.toHaveBeenCalled();
         expect(el.querySelector('.ti-stack-options-container')).toBeNull();
         expect(el.querySelector('.ti-no-stack-container')).toBeNull();
         sub?.unsubscribe();
@@ -327,7 +327,7 @@ describe('ThirdIronButtonsComponent', () => {
       it('hides the wrapping ng-component so the host flex container gap does not apply', async () => {
         const { component, sub } = await setupSkipEnhancement();
 
-        expect(component.hideHostWrapper).toHaveBeenCalled();
+        expect(component.availabilityDom.hideWrapper).toHaveBeenCalled();
         sub?.unsubscribe();
       });
     });
@@ -817,12 +817,14 @@ describe('ThirdIronButtonsComponent', () => {
     // When moving to a non-enhanced record, we should redraw the original Primo UI (restores Primo availability) and reset the enhancement state.
     it('resets enhancement state and restores Primo availability when transitioning from enhanced -> non-enhanced record', async () => {
       const { fixture, component, getDisplayInfoSpy } = await setupNavigationFixture();
-      const removeSpy = spyOn(component, 'removePrimoOnlineAvailability').and.returnValue(1);
-      const restoreSpy = spyOn(component, 'restorePrimoOnlineAvailability').and.returnValue(1);
+      const removeSpy = spyOn(component.availabilityDom, 'hideAvailability').and.returnValue(1);
+      const restoreSpy = spyOn(component.availabilityDom, 'restoreAvailability').and.returnValue(1);
       // Track host-wrapper toggling: when processing an enhanced record, we should restore the wrapper, transitioning
       // to a non-enhanced (empty render) record should then hide it again.
-      const hideWrapperSpy = spyOn(component, 'hideHostWrapper').and.returnValue(true);
-      const restoreWrapperSpy = spyOn(component, 'restoreHostWrapper').and.returnValue(true);
+      const hideWrapperSpy = spyOn(component.availabilityDom, 'hideWrapper').and.returnValue(true);
+      const restoreWrapperSpy = spyOn(component.availabilityDom, 'restoreWrapper').and.returnValue(
+        true
+      );
 
       fixture.detectChanges();
       const sub = component.displayInfo$?.subscribe();
@@ -851,12 +853,14 @@ describe('ThirdIronButtonsComponent', () => {
     it('enhances and removes Primo availability when navigating from a non-enhanced -> enhanced record', async () => {
       const { fixture, component, getDisplayInfoSpy, buildCombinedLinksSpy } =
         await setupNavigationFixture();
-      const removeSpy = spyOn(component, 'removePrimoOnlineAvailability').and.returnValue(1);
-      const restoreSpy = spyOn(component, 'restorePrimoOnlineAvailability').and.returnValue(1);
+      const removeSpy = spyOn(component.availabilityDom, 'hideAvailability').and.returnValue(1);
+      const restoreSpy = spyOn(component.availabilityDom, 'restoreAvailability').and.returnValue(1);
       // Track host-wrapper toggling: non-enhanced render should hide the wrapper,
       // transitioning to an enhanced record should restore it.
-      const hideWrapperSpy = spyOn(component, 'hideHostWrapper').and.returnValue(true);
-      const restoreWrapperSpy = spyOn(component, 'restoreHostWrapper').and.returnValue(true);
+      const hideWrapperSpy = spyOn(component.availabilityDom, 'hideWrapper').and.returnValue(true);
+      const restoreWrapperSpy = spyOn(component.availabilityDom, 'restoreWrapper').and.returnValue(
+        true
+      );
 
       component.hostComponent.searchResult = nonEnhancedArticleRecord;
 
@@ -964,10 +968,10 @@ describe('ThirdIronButtonsComponent', () => {
       fixture = TestBed.createComponent(ThirdIronButtonsComponent);
       component = fixture.componentInstance;
       component.viewOption = ViewOptionType.StackPlusBrowzine;
-      removeSpy = spyOn(component, 'removePrimoOnlineAvailability').and.returnValue(1);
-      restoreSpy = spyOn(component, 'restorePrimoOnlineAvailability').and.returnValue(1);
-      spyOn(component, 'restoreHostWrapper').and.returnValue(true);
-      spyOn(component, 'hideHostWrapper').and.returnValue(true);
+      removeSpy = spyOn(component.availabilityDom, 'hideAvailability').and.returnValue(1);
+      restoreSpy = spyOn(component.availabilityDom, 'restoreAvailability').and.returnValue(1);
+      spyOn(component.availabilityDom, 'restoreWrapper').and.returnValue(true);
+      spyOn(component.availabilityDom, 'hideWrapper').and.returnValue(true);
       component.hostComponent = {
         searchResult: enhancedArticleRecord,
         viewModel$: of({ onlineLinks: [], directLink: '', ariaLabel: '' }),
@@ -1037,6 +1041,44 @@ describe('ThirdIronButtonsComponent', () => {
 
       fixture.destroy();
     }));
+
+    // The core race: our component is injected before `nde-online-availability`, so the native
+    // element frequently doesn't exist yet when we first try to hide it. The observer must hide it
+    // the moment Primo renders it. Here we let the real hide/observer logic run (no spies) and add
+    // the native element to the DOM *after* entering the loading phase.
+    it('hides a native availability element that Primo renders after loading starts', async () => {
+      // Use the real hide + observer logic for this test (undo the beforeEach spies).
+      removeSpy.and.callThrough();
+
+      const wrapper = document.createElement('ng-component');
+      const container = document.createElement('div');
+      container.appendChild(wrapper);
+      // Place our component's host element inside the wrapper so the controller's observer root
+      // resolves to the container.
+      wrapper.appendChild(fixture.nativeElement);
+      document.body.appendChild(container);
+
+      try {
+        fixture.detectChanges(); // enters loading + starts the observer
+        expect(component.buttonsPhase).toBe('loading');
+
+        // Native element rendered by Primo *after* we started loading.
+        const nativeAvailability = document.createElement('nde-online-availability');
+        container.appendChild(nativeAvailability);
+
+        // Let the MutationObserver callback run.
+        await Promise.resolve();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(
+          nativeAvailability.classList.contains('ti-online-availability-hidden')
+        ).toBeTrue();
+        expect(nativeAvailability.style.display).toBe('none');
+      } finally {
+        fixture.destroy();
+        document.body.removeChild(container);
+      }
+    });
   });
 
   it('passes translated Primo labels into buildPrimoLinks and updates when translation streams emit', async () => {

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.spec.ts
@@ -16,6 +16,23 @@ import { TranslateService } from '@ngx-translate/core';
 import { EntityType } from 'src/app/shared/entity-type.enum';
 import { ButtonType } from 'src/app/shared/button-type.enum';
 import { DebugLogService } from 'src/app/services/debug-log.service';
+import { PrimoAvailabilityDomController } from 'src/app/shared/primo-availability-dom';
+
+// The component injects PrimoAvailabilityDomController (component-scoped provider). Its real DOM
+// behavior is unit-tested directly in primo-availability-dom.spec.ts, so here we swap in a spy
+// object via DI and just assert that the component calls it at the right times. Because the
+// controller is provided at the component level, tests override it with TestBed.overrideProvider.
+type AvailabilityDomFake = jasmine.SpyObj<PrimoAvailabilityDomController>;
+const createAvailabilityDomFake = (): AvailabilityDomFake =>
+  jasmine.createSpyObj<PrimoAvailabilityDomController>('PrimoAvailabilityDomController', {
+    hideAvailability: 1,
+    restoreAvailability: 1,
+    hideWrapper: true,
+    restoreWrapper: true,
+    isObserving: false,
+    observeAvailability: undefined,
+    disconnect: undefined,
+  });
 
 @Component({
   selector: 'stacked-dropdown',
@@ -88,7 +105,9 @@ describe('ThirdIronButtonsComponent', () => {
           },
         },
       ],
-    }).compileComponents();
+    })
+      .overrideProvider(PrimoAvailabilityDomController, { useValue: createAvailabilityDomFake() })
+      .compileComponents();
   });
 
   it('should create component successfully', () => {
@@ -136,6 +155,7 @@ describe('ThirdIronButtonsComponent', () => {
             ],
           },
         })
+        .overrideProvider(PrimoAvailabilityDomController, { useValue: createAvailabilityDomFake() })
         .compileComponents();
     });
 
@@ -273,6 +293,9 @@ describe('ThirdIronButtonsComponent', () => {
               ],
             },
           })
+          .overrideProvider(PrimoAvailabilityDomController, {
+            useValue: createAvailabilityDomFake(),
+          })
           .compileComponents();
 
         const fixture = TestBed.createComponent(ThirdIronButtonsComponent);
@@ -282,12 +305,6 @@ describe('ThirdIronButtonsComponent', () => {
           searchResult: makeArticleIssnNoDoi(),
           viewModel$: of({}),
         };
-
-        // Spy on side-effect method to ensure enhancement pipeline didn't run.
-        spyOn(component.availabilityDom, 'hideAvailability').and.callThrough();
-        // Spy on host-wrapper toggling so tests can assert we collapse the wrapping
-        // `<ng-component>` to avoid the host flex container's `gap` rule applying.
-        spyOn(component.availabilityDom, 'hideWrapper').and.callThrough();
 
         fixture.detectChanges(); // runs ngOnInit
         // Ensure the Rx pipeline runs by subscribing (in the real app the template async pipe does this).
@@ -747,6 +764,7 @@ describe('ThirdIronButtonsComponent', () => {
     };
 
     const setupNavigationFixture = async () => {
+      const availabilityDom = createAvailabilityDomFake();
       const viewModel$ = new BehaviorSubject<any>({
         onlineLinks: [],
         directLink: '/fulldisplay?docid=rec-enhanced',
@@ -799,6 +817,7 @@ describe('ThirdIronButtonsComponent', () => {
             ],
           },
         })
+        .overrideProvider(PrimoAvailabilityDomController, { useValue: availabilityDom })
         .compileComponents();
 
       const fixture = TestBed.createComponent(ThirdIronButtonsComponent);
@@ -810,21 +829,20 @@ describe('ThirdIronButtonsComponent', () => {
         viewModel$: viewModel$.asObservable(),
       };
 
-      return { fixture, component, getDisplayInfoSpy, buildCombinedLinksSpy };
+      return { fixture, component, getDisplayInfoSpy, buildCombinedLinksSpy, availabilityDom };
     };
 
     // The scenario here is when stepping through fulldisplay records and moving from a record enhanced by Third Iron to a record that is not enhanced by Third Iron.
     // When moving to a non-enhanced record, we should redraw the original Primo UI (restores Primo availability) and reset the enhancement state.
     it('resets enhancement state and restores Primo availability when transitioning from enhanced -> non-enhanced record', async () => {
-      const { fixture, component, getDisplayInfoSpy } = await setupNavigationFixture();
-      const removeSpy = spyOn(component.availabilityDom, 'hideAvailability').and.returnValue(1);
-      const restoreSpy = spyOn(component.availabilityDom, 'restoreAvailability').and.returnValue(1);
+      const { fixture, component, getDisplayInfoSpy, availabilityDom } =
+        await setupNavigationFixture();
+      const removeSpy = availabilityDom.hideAvailability;
+      const restoreSpy = availabilityDom.restoreAvailability;
       // Track host-wrapper toggling: when processing an enhanced record, we should restore the wrapper, transitioning
       // to a non-enhanced (empty render) record should then hide it again.
-      const hideWrapperSpy = spyOn(component.availabilityDom, 'hideWrapper').and.returnValue(true);
-      const restoreWrapperSpy = spyOn(component.availabilityDom, 'restoreWrapper').and.returnValue(
-        true
-      );
+      const hideWrapperSpy = availabilityDom.hideWrapper;
+      const restoreWrapperSpy = availabilityDom.restoreWrapper;
 
       fixture.detectChanges();
       const sub = component.displayInfo$?.subscribe();
@@ -851,16 +869,14 @@ describe('ThirdIronButtonsComponent', () => {
     });
 
     it('enhances and removes Primo availability when navigating from a non-enhanced -> enhanced record', async () => {
-      const { fixture, component, getDisplayInfoSpy, buildCombinedLinksSpy } =
+      const { fixture, component, getDisplayInfoSpy, buildCombinedLinksSpy, availabilityDom } =
         await setupNavigationFixture();
-      const removeSpy = spyOn(component.availabilityDom, 'hideAvailability').and.returnValue(1);
-      const restoreSpy = spyOn(component.availabilityDom, 'restoreAvailability').and.returnValue(1);
+      const removeSpy = availabilityDom.hideAvailability;
+      const restoreSpy = availabilityDom.restoreAvailability;
       // Track host-wrapper toggling: non-enhanced render should hide the wrapper,
       // transitioning to an enhanced record should restore it.
-      const hideWrapperSpy = spyOn(component.availabilityDom, 'hideWrapper').and.returnValue(true);
-      const restoreWrapperSpy = spyOn(component.availabilityDom, 'restoreWrapper').and.returnValue(
-        true
-      );
+      const hideWrapperSpy = availabilityDom.hideWrapper;
+      const restoreWrapperSpy = availabilityDom.restoreWrapper;
 
       component.hostComponent.searchResult = nonEnhancedArticleRecord;
 
@@ -923,11 +939,13 @@ describe('ThirdIronButtonsComponent', () => {
     let displayInfoSubject: Subject<any>;
     let fixture: ReturnType<typeof TestBed.createComponent<ThirdIronButtonsComponent>>;
     let component: ThirdIronButtonsComponent;
+    let availabilityDom: AvailabilityDomFake;
     let removeSpy: jasmine.Spy;
     let restoreSpy: jasmine.Spy;
 
     beforeEach(async () => {
       displayInfoSubject = new Subject<any>();
+      availabilityDom = createAvailabilityDomFake();
 
       await TestBed.resetTestingModule()
         .configureTestingModule({
@@ -963,15 +981,14 @@ describe('ThirdIronButtonsComponent', () => {
             ],
           },
         })
+        .overrideProvider(PrimoAvailabilityDomController, { useValue: availabilityDom })
         .compileComponents();
 
       fixture = TestBed.createComponent(ThirdIronButtonsComponent);
       component = fixture.componentInstance;
       component.viewOption = ViewOptionType.StackPlusBrowzine;
-      removeSpy = spyOn(component.availabilityDom, 'hideAvailability').and.returnValue(1);
-      restoreSpy = spyOn(component.availabilityDom, 'restoreAvailability').and.returnValue(1);
-      spyOn(component.availabilityDom, 'restoreWrapper').and.returnValue(true);
-      spyOn(component.availabilityDom, 'hideWrapper').and.returnValue(true);
+      removeSpy = availabilityDom.hideAvailability;
+      restoreSpy = availabilityDom.restoreAvailability;
       component.hostComponent = {
         searchResult: enhancedArticleRecord,
         viewModel$: of({ onlineLinks: [], directLink: '', ariaLabel: '' }),
@@ -1041,44 +1058,6 @@ describe('ThirdIronButtonsComponent', () => {
 
       fixture.destroy();
     }));
-
-    // The core race: our component is injected before `nde-online-availability`, so the native
-    // element frequently doesn't exist yet when we first try to hide it. The observer must hide it
-    // the moment Primo renders it. Here we let the real hide/observer logic run (no spies) and add
-    // the native element to the DOM *after* entering the loading phase.
-    it('hides a native availability element that Primo renders after loading starts', async () => {
-      // Use the real hide + observer logic for this test (undo the beforeEach spies).
-      removeSpy.and.callThrough();
-
-      const wrapper = document.createElement('ng-component');
-      const container = document.createElement('div');
-      container.appendChild(wrapper);
-      // Place our component's host element inside the wrapper so the controller's observer root
-      // resolves to the container.
-      wrapper.appendChild(fixture.nativeElement);
-      document.body.appendChild(container);
-
-      try {
-        fixture.detectChanges(); // enters loading + starts the observer
-        expect(component.buttonsPhase).toBe('loading');
-
-        // Native element rendered by Primo *after* we started loading.
-        const nativeAvailability = document.createElement('nde-online-availability');
-        container.appendChild(nativeAvailability);
-
-        // Let the MutationObserver callback run.
-        await Promise.resolve();
-        await new Promise(resolve => setTimeout(resolve, 0));
-
-        expect(
-          nativeAvailability.classList.contains('ti-online-availability-hidden')
-        ).toBeTrue();
-        expect(nativeAvailability.style.display).toBe('none');
-      } finally {
-        fixture.destroy();
-        document.body.removeChild(container);
-      }
-    });
   });
 
   it('passes translated Primo labels into buildPrimoLinks and updates when translation streams emit', async () => {
@@ -1149,6 +1128,7 @@ describe('ThirdIronButtonsComponent', () => {
         },
       })
       .overrideProvider(ButtonInfoService, { useValue: buttonInfoMock })
+      .overrideProvider(PrimoAvailabilityDomController, { useValue: createAvailabilityDomFake() })
       .compileComponents();
 
     const fixture = TestBed.createComponent(ThirdIronButtonsComponent);
@@ -1230,6 +1210,7 @@ describe('ThirdIronButtonsComponent', () => {
         },
       })
       .overrideProvider(ButtonInfoService, { useValue: buttonInfoMock })
+      .overrideProvider(PrimoAvailabilityDomController, { useValue: createAvailabilityDomFake() })
       .compileComponents();
 
     const fixture = TestBed.createComponent(ThirdIronButtonsComponent);

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
@@ -34,6 +34,7 @@ import {
   resolvePrimoHostRecord,
 } from 'src/app/shared/primo-host-record.utils';
 import { TranslationService } from 'src/app/services/translation.service';
+import { PrimoAvailabilityDomController } from 'src/app/shared/primo-availability-dom';
 
 @Component({
   selector: 'custom-third-iron-buttons',
@@ -114,6 +115,12 @@ export class ThirdIronButtonsComponent {
   private enhanceCommitTimer: ReturnType<typeof setTimeout> | null = null;
   private maxWaitTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // Owns all DOM coordination with the host Primo `nde-online-availability` element (hiding,
+  // restoring, and observing for late/re-renders) and the `<ng-component>` wrapper. Kept public so
+  // the side-effects can be spied in tests. Because we're injected *before* the native element, the
+  // eager one-shot hide can run before Primo has created it — the observer covers that race.
+  readonly availabilityDom = new PrimoAvailabilityDomController();
+
   // Expose enum to template
   ViewOptionType = ViewOptionType;
 
@@ -177,6 +184,7 @@ export class ThirdIronButtonsComponent {
 
   ngOnDestroy() {
     this.clearPhaseTimers();
+    this.availabilityDom.disconnect();
     this.hostProxy.destroy();
   }
 
@@ -267,7 +275,22 @@ export class ThirdIronButtonsComponent {
     }
 
     // We are enhancing this record with at least one TI-provided button (main/secondary/BrowZine).
-    // The native Primo online availability UI was already hidden in enterLoading(); keep it hidden.
+    // The native Primo online availability UI was hidden in enterLoading(); re-hide now that the
+    // call has settled (by this point the native element definitely exists) and ensure the observer
+    // is still guarding against Primo re-rendering it. Keep our wrapper visible so our buttons show.
+    {
+      const hostElem = this.elementRef.nativeElement as HTMLElement;
+      const removedCount = this.availabilityDom.hideAvailability(hostElem);
+      const wrapperRestored = this.availabilityDom.restoreWrapper(hostElem);
+      if (!this.availabilityDom.isObserving()) {
+        this.availabilityDom.observeAvailability(hostElem, () => this.isGuardingNativeButtons());
+      }
+      this.debugLog.debug('ThirdIronButtons.applyEnhancement.hideNative', {
+        removedCount,
+        wrapperRestored,
+      });
+    }
+
     if (viewOption !== ViewOptionType.NoStack) {
       // build custom stack options array for StackPlusBrowzine and SingleStack view options
       // Clear stale NoStack links so template can't get "stuck" on old state.
@@ -310,9 +333,12 @@ export class ThirdIronButtonsComponent {
     this.skeletonShownAt = null;
 
     const hostElem = this.elementRef.nativeElement as HTMLElement;
-    const removedCount = this.removePrimoOnlineAvailability(hostElem);
+    const removedCount = this.availabilityDom.hideAvailability(hostElem);
+    // Keep the native element hidden even if Primo renders it *after* us (the common race: we're
+    // injected before `nde-online-availability`, so it may not exist yet at this point).
+    this.availabilityDom.observeAvailability(hostElem, () => this.isGuardingNativeButtons());
     // Make sure our wrapper is visible so the skeleton (and later, our buttons) can render.
-    const wrapperRestored = this.restoreHostWrapper(hostElem);
+    const wrapperRestored = this.availabilityDom.restoreWrapper(hostElem);
     this.debugLog.debug('ThirdIronButtons.enterLoading', {
       removedCount,
       wrapperRestored,
@@ -383,24 +409,33 @@ export class ThirdIronButtonsComponent {
    */
   private enterPassthrough(reason: string): void {
     this.clearPhaseTimers();
+    // Stop guarding the native element *before* restoring it, otherwise the observer would
+    // immediately re-hide what we're trying to reveal.
+    this.availabilityDom.disconnect();
     this.resetEnhancementState();
     this.showSkeleton = false;
     this.skeletonShownAt = null;
     this.buttonsPhase = 'passthrough';
 
     const hostElem = this.elementRef.nativeElement as HTMLElement;
-    const restoredCount = this.restorePrimoOnlineAvailability(hostElem);
+    const restoredCount = this.availabilityDom.restoreAvailability(hostElem);
     this.debugLog.debug('ThirdIronButtons.restorePrimoOnlineAvailability', {
       reason,
       restoredCount,
     });
     // We render nothing in this case; collapse our wrapper so the host flex container's
     // gap doesn't apply between us and the sibling `nde-online-availability`.
-    const wrapperHidden = this.hideHostWrapper(hostElem);
+    const wrapperHidden = this.availabilityDom.hideWrapper(hostElem);
     this.debugLog.debug('ThirdIronButtons.hideHostWrapper', {
       reason,
       wrapperHidden,
     });
+  }
+
+  // While loading or enhancing, we intend to keep the native Primo buttons hidden; the availability
+  // observer uses this as its guard so it stops re-hiding once we've handed control back to Primo.
+  private isGuardingNativeButtons(): boolean {
+    return this.buttonsPhase === 'loading' || this.buttonsPhase === 'enhanced';
   }
 
   private clearPhaseTimers(): void {
@@ -439,111 +474,5 @@ export class ThirdIronButtonsComponent {
     this.hasThirdIronSourceItems = false;
     this.combinedLinks = [];
     this.primoLinks = [];
-  }
-
-  removePrimoOnlineAvailability = (hostElement: HTMLElement): number => {
-    // This component is injected *before* the host `nde-online-availability` block.
-    // Depending on the host (and `ngComponentOutlet`), our host element may be an `<ng-component>`
-    // node or some other wrapper. Walk up the DOM until we find an ancestor that actually contains
-    // the `nde-online-availability` element, then hide it.
-    // Choosing to look up the tree to a depth of 12 is arbitrary, but seemed a reasonable depth.
-    let current: HTMLElement | null = hostElement ?? null;
-    for (let depth = 0; current && depth < 12; depth++) {
-      const onlineAvailabilityElems = current.getElementsByTagName(
-        'nde-online-availability'
-      ) as HTMLCollectionOf<HTMLElement>;
-      if (onlineAvailabilityElems.length > 0) {
-        const arr = Array.from(onlineAvailabilityElems);
-        for (const elem of arr) {
-          if (elem.dataset['tiOnlineAvailabilityPrevDisplay'] === undefined) {
-            // if we need to restore this element later, we will set display back to the original value
-            elem.dataset['tiOnlineAvailabilityPrevDisplay'] = elem.style.display ?? '';
-          }
-          elem.dataset['tiOnlineAvailabilityHiddenByThirdIron'] = '1';
-          elem.style.display = 'none';
-        }
-        return arr.length;
-      }
-      current = current.parentElement;
-    }
-
-    this.debugLog.debug('ThirdIronButtons.removePrimoOnlineAvailability.notFound', {
-      maxDepth: 12,
-    });
-    return 0;
-  };
-
-  // Traverse the DOM up to 12 levels (arbitrary depth) to find the `nde-online-availability` element and restore it to its original display value.
-  // We only restore elements we previously hid (tiOnlineAvailabilityHiddenByThirdIron dataset is set to '1')
-  // After restoring, we delete the tiOnlineAvailabilityHiddenByThirdIron and tiOnlineAvailabilityPrevDisplay dataset attributes (cleanup).
-  restorePrimoOnlineAvailability = (hostElement: HTMLElement): number => {
-    let current: HTMLElement | null = hostElement ?? null;
-    for (let depth = 0; current && depth < 12; depth++) {
-      const onlineAvailabilityElems = current.getElementsByTagName(
-        'nde-online-availability'
-      ) as HTMLCollectionOf<HTMLElement>;
-      if (onlineAvailabilityElems.length > 0) {
-        const arr = Array.from(onlineAvailabilityElems);
-        let restored = 0;
-        for (const elem of arr) {
-          if (elem.dataset['tiOnlineAvailabilityHiddenByThirdIron'] !== '1') continue;
-          const prevDisplay = elem.dataset['tiOnlineAvailabilityPrevDisplay'];
-          elem.style.display = prevDisplay ?? '';
-          delete elem.dataset['tiOnlineAvailabilityHiddenByThirdIron'];
-          delete elem.dataset['tiOnlineAvailabilityPrevDisplay'];
-          restored++;
-        }
-        return restored;
-      }
-      current = current.parentElement;
-    }
-    return 0;
-  };
-
-  // The host (Primo NDE) renders this component via `*ngComponentOutlet`, which wraps our
-  // custom element in an `<ng-component>` element. That `<ng-component>` is a direct child
-  // of the host's `.responsive-availability-layout` flex container (which currently sets `gap: .5rem`).
-  //
-  // When this component has nothing to render (no TI buttons), our own host element is empty
-  // (just Angular `<!---->` placeholders), but `<ng-component>` is still a flex item — so the
-  // container's gap is still applied between it and the sibling `<nde-online-availability>`,
-  // leaving an unwanted blank space to the left of the Primo "Available Online" button.
-  //
-  // Hiding our own host element doesn't fix this (the flex item is the wrapper, not us), so
-  // we walk up to the wrapping `<ng-component>` and hide it instead. We mark our mutation
-  // with dataset flags so `restoreHostWrapper` only undoes changes we made.
-  hideHostWrapper = (hostElement: HTMLElement): boolean => {
-    const wrapper = this.findHostWrapper(hostElement);
-    if (!wrapper) return false;
-    if (wrapper.dataset['tiWrapperPrevDisplay'] === undefined) {
-      wrapper.dataset['tiWrapperPrevDisplay'] = wrapper.style.display ?? '';
-    }
-    wrapper.dataset['tiWrapperHiddenByThirdIron'] = '1';
-    wrapper.style.display = 'none';
-    return true;
-  };
-
-  // Restore the wrapping `<ng-component>`'s display if (and only if) we previously hid it.
-  restoreHostWrapper = (hostElement: HTMLElement): boolean => {
-    const wrapper = this.findHostWrapper(hostElement);
-    if (!wrapper) return false;
-    if (wrapper.dataset['tiWrapperHiddenByThirdIron'] !== '1') return false;
-    const prevDisplay = wrapper.dataset['tiWrapperPrevDisplay'];
-    wrapper.style.display = prevDisplay ?? '';
-    delete wrapper.dataset['tiWrapperHiddenByThirdIron'];
-    delete wrapper.dataset['tiWrapperPrevDisplay'];
-    return true;
-  };
-
-  // Walk up a small fixed number of levels from our host element looking for the
-  // `<ng-component>` wrapper. Depth is normally 1, but we allow a few hops in case
-  // a future host inserts an extra wrapper.
-  private findHostWrapper(hostElement: HTMLElement | null): HTMLElement | null {
-    let current: HTMLElement | null = hostElement?.parentElement ?? null;
-    for (let depth = 0; current && depth < 4; depth++) {
-      if (current.tagName.toLowerCase() === 'ng-component') return current;
-      current = current.parentElement;
-    }
-    return null;
   }
 }

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
@@ -91,6 +91,29 @@ export class ThirdIronButtonsComponent {
   viewOption = this.configService.getViewOption();
   hasThirdIronSourceItems = false;
 
+  // **Render phase / anti-flash state**
+  // The host (Primo) paints its native `nde-online-availability` buttons immediately, but our
+  // enhancement decision depends on an async LibKey call. To avoid the "native buttons flash then
+  // get replaced" effect, we hide the native buttons *eagerly* (as soon as we know a record is
+  // enhance-eligible) and show a loading skeleton until the call settles.
+  //  - 'idle'        : nothing decided yet (initial)
+  //  - 'loading'     : eligible record, LibKey call in-flight; native buttons hidden, skeleton reserved
+  //  - 'enhanced'    : LibKey settled with TI content; render our buttons
+  //  - 'passthrough' : not eligible / no TI content; native Primo buttons shown, we render nothing
+  buttonsPhase: 'idle' | 'loading' | 'enhanced' | 'passthrough' = 'idle';
+  // Only becomes true once the skeleton-delay has elapsed, so fast/cached responses never flash a shimmer.
+  showSkeleton = false;
+
+  // Timing guards (ms). Kept as constants for easy tuning.
+  private readonly SKELETON_DELAY_MS = 150; // don't show the shimmer for fast/cached responses
+  private readonly SKELETON_MIN_VISIBLE_MS = 400; // once shown, keep it visible at least this long
+  private readonly MAX_WAIT_MS = 8000; // fallback: restore native buttons if the call never settles
+
+  private skeletonShownAt: number | null = null;
+  private skeletonDelayTimer: ReturnType<typeof setTimeout> | null = null;
+  private enhanceCommitTimer: ReturnType<typeof setTimeout> | null = null;
+  private maxWaitTimer: ReturnType<typeof setTimeout> | null = null;
+
   // Expose enum to template
   ViewOptionType = ViewOptionType;
 
@@ -153,6 +176,7 @@ export class ThirdIronButtonsComponent {
   }
 
   ngOnDestroy() {
+    this.clearPhaseTimers();
     this.hostProxy.destroy();
   }
 
@@ -178,20 +202,7 @@ export class ThirdIronButtonsComponent {
             'ThirdIronButtons.enhance.skip',
             this.debugLog.safeSearchEntityMeta(record)
           );
-          this.resetEnhancementState();
-          const hostElem = this.elementRef.nativeElement as HTMLElement;
-          const restoredCount = this.restorePrimoOnlineAvailability(hostElem);
-          this.debugLog.debug('ThirdIronButtons.restorePrimoOnlineAvailability', {
-            reason: 'shouldEnhanceButtons=false',
-            restoredCount,
-          });
-          // We render nothing in this case; collapse our wrapper so the host flex container's
-          // gap doesn't apply between us and the sibling `nde-online-availability`.
-          const wrapperHidden = this.hideHostWrapper(hostElem);
-          this.debugLog.debug('ThirdIronButtons.hideHostWrapper', {
-            reason: 'shouldEnhanceButtons=false',
-            wrapperHidden,
-          });
+          this.enterPassthrough('shouldEnhanceButtons=false');
           return of(null);
         }
 
@@ -200,93 +211,211 @@ export class ThirdIronButtonsComponent {
           ...this.debugLog.safeSearchEntityMeta(record),
         });
 
+        // Eagerly hide the native Primo buttons and show a loading state *before* the LibKey call
+        // resolves. This is what removes the flash: the user never sees the native buttons for
+        // enhance-eligible records.
+        this.enterLoading();
+
         return combineLatest([
           this.buttonInfoService.getDisplayInfo(record),
           this.viewModel$,
           this.primoLinkLabels$,
         ]).pipe(
-          map(([displayInfo, viewModel, primoLinkLabels]) => {
-            this.debugLog.debug('ThirdIronButtons.viewModel', {
-              ...getPrimoViewModelMeta(viewModel),
-              ariaLabel: viewModel?.ariaLabel ?? null,
-            });
-
-            const viewOption = this.viewOption;
-
-            // If the TI API / waterfall yields no TI-specific button(s), we should leave the host Primo UI
-            // untouched and render nothing from this component.
-            this.hasThirdIronSourceItems = this.hasThirdIronAdditions(displayInfo);
-
-            if (!this.hasThirdIronSourceItems) {
-              this.resetEnhancementState();
-              const hostElem = this.elementRef.nativeElement as HTMLElement;
-              const restoredCount = this.restorePrimoOnlineAvailability(hostElem);
-              this.debugLog.debug('ThirdIronButtons.restorePrimoOnlineAvailability', {
-                reason: 'hasThirdIronSourceItems=false',
-                restoredCount,
-              });
-              // We render nothing in this case; collapse our wrapper so the host flex container's
-              // gap doesn't apply between us and the sibling `nde-online-availability`.
-              const wrapperHidden = this.hideHostWrapper(hostElem);
-              this.debugLog.debug('ThirdIronButtons.hideHostWrapper', {
-                reason: 'hasThirdIronSourceItems=false',
-                wrapperHidden,
-              });
-              return displayInfo;
-            }
-
-            // We are enhancing this record with at least one TI-provided button (main/secondary/BrowZine).
-            // Hide the host Primo online availability UI so we don't show duplicate "Online access available"
-            // buttons alongside our custom buttons (notably, BrowZine-only records).
-            {
-              const hostElem = this.elementRef.nativeElement as HTMLElement; // this component's host element
-              const removedCount = this.removePrimoOnlineAvailability(hostElem);
-              this.debugLog.debug('ThirdIronButtons.removePrimoOnlineAvailability', {
-                reason: 'hasThirdIronSourceItems',
-                removedCount,
-              });
-              // If a previous emission (for this or another record) had hidden our wrapper because
-              // we were empty, make sure it's visible again now that we have content to render.
-              const wrapperRestored = this.restoreHostWrapper(hostElem);
-              this.debugLog.debug('ThirdIronButtons.restoreHostWrapper', {
-                reason: 'hasThirdIronSourceItems',
-                wrapperRestored,
-              });
-            }
-
-            if (viewOption !== ViewOptionType.NoStack) {
-              // build custom stack options array for StackPlusBrowzine and SingleStack view options
-              // Clear stale NoStack links so template can't get "stuck" on old state.
-              this.primoLinks = [];
-              this.combinedLinks = this.buttonInfoService.buildCombinedLinks(
-                displayInfo,
-                viewModel,
-                primoLinkLabels
-              );
-
-              this.debugLog.debug('ThirdIronButtons.combinedLinks', {
-                combinedLinks: this.combinedLinks,
-              });
-            } else {
-              // Build array of Primo only links, filter based on TI config settings.
-              // Pass the record's entity type so the link resolver (direct) link can be
-              // shown/hidden per entity type (article vs journal).
-              this.combinedLinks = [];
-              this.primoLinks = this.buttonInfoService.buildPrimoLinks(
-                viewModel,
-                primoLinkLabels,
-                displayInfo.entityType
-              );
-
-              // Primo links are re-rendered via our own `stacked-dropdown` in NoStack mode.
-            }
-
-            return displayInfo;
-          })
+          map(([displayInfo, viewModel, primoLinkLabels]) =>
+            this.applyEnhancement(displayInfo, viewModel, primoLinkLabels)
+          )
         );
       }),
-      takeUntilDestroyed(this.destroyRef)
+      takeUntilDestroyed(this.destroyRef),
+      shareReplay({ bufferSize: 1, refCount: true })
     );
+
+    // The template only reads displayInfo$/viewModel$ (via async pipe) inside the
+    // `buttonsPhase === 'enhanced'` block, but it's this very pipeline that *sets* buttonsPhase and
+    // performs the eager-hide / skeleton side-effects. Subscribe here so the phase transitions run
+    // regardless of what the template is currently rendering. shareReplay lets the template's later
+    // async-pipe subscription share this same source (so we don't issue duplicate LibKey calls).
+    this.displayInfo$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
+  }
+
+  /**
+   * Process a settled LibKey result: decide whether we actually have Third Iron content and
+   * transition to the appropriate render phase. Extracted from the pipeline so the loading /
+   * enhanced / passthrough transitions live in one place.
+   */
+  private applyEnhancement(
+    displayInfo: DisplayWaterfallResponse,
+    viewModel: PrimoViewModel,
+    primoLinkLabels: Parameters<ButtonInfoService['buildCombinedLinks']>[2]
+  ): DisplayWaterfallResponse {
+    this.debugLog.debug('ThirdIronButtons.viewModel', {
+      ...getPrimoViewModelMeta(viewModel),
+      ariaLabel: viewModel?.ariaLabel ?? null,
+    });
+
+    const viewOption = this.viewOption;
+
+    // If the TI API / waterfall yields no TI-specific button(s), we should leave the host Primo UI
+    // untouched and render nothing from this component.
+    this.hasThirdIronSourceItems = this.hasThirdIronAdditions(displayInfo);
+
+    if (!this.hasThirdIronSourceItems) {
+      // Rarer "reverse" path: we eagerly hid the native buttons but there's no TI content to show,
+      // so restore them. enterPassthrough handles restore + wrapper collapse + phase reset.
+      this.enterPassthrough('hasThirdIronSourceItems=false');
+      return displayInfo;
+    }
+
+    // We are enhancing this record with at least one TI-provided button (main/secondary/BrowZine).
+    // The native Primo online availability UI was already hidden in enterLoading(); keep it hidden.
+    if (viewOption !== ViewOptionType.NoStack) {
+      // build custom stack options array for StackPlusBrowzine and SingleStack view options
+      // Clear stale NoStack links so template can't get "stuck" on old state.
+      this.primoLinks = [];
+      this.combinedLinks = this.buttonInfoService.buildCombinedLinks(
+        displayInfo,
+        viewModel,
+        primoLinkLabels
+      );
+
+      this.debugLog.debug('ThirdIronButtons.combinedLinks', {
+        combinedLinks: this.combinedLinks,
+      });
+    } else {
+      // Build array of Primo only links, filter based on TI config settings.
+      // Pass the record's entity type so the link resolver (direct) link can be
+      // shown/hidden per entity type (article vs journal).
+      this.combinedLinks = [];
+      this.primoLinks = this.buttonInfoService.buildPrimoLinks(
+        viewModel,
+        primoLinkLabels,
+        displayInfo.entityType
+      );
+
+      // Primo links are re-rendered via our own `stacked-dropdown` in NoStack mode.
+    }
+
+    this.commitEnhanced();
+    return displayInfo;
+  }
+
+  /**
+   * Enter the loading phase for an enhance-eligible record: hide the native Primo buttons now,
+   * reserve space for our skeleton, and arm the skeleton-delay + max-wait timers.
+   */
+  private enterLoading(): void {
+    this.clearPhaseTimers();
+    this.buttonsPhase = 'loading';
+    this.showSkeleton = false;
+    this.skeletonShownAt = null;
+
+    const hostElem = this.elementRef.nativeElement as HTMLElement;
+    const removedCount = this.removePrimoOnlineAvailability(hostElem);
+    // Make sure our wrapper is visible so the skeleton (and later, our buttons) can render.
+    const wrapperRestored = this.restoreHostWrapper(hostElem);
+    this.debugLog.debug('ThirdIronButtons.enterLoading', {
+      removedCount,
+      wrapperRestored,
+    });
+
+    // Only reveal the shimmer if loading actually takes a noticeable amount of time. This avoids a
+    // sub-150ms flash for fast/cached responses (native hidden -> straight to our buttons).
+    this.skeletonDelayTimer = setTimeout(() => {
+      this.skeletonDelayTimer = null;
+      if (this.buttonsPhase !== 'loading') return;
+      this.showSkeleton = true;
+      this.skeletonShownAt = Date.now();
+      this.debugLog.debug('ThirdIronButtons.skeleton.show', {});
+    }, this.SKELETON_DELAY_MS);
+
+    // Safety net: if the call never settles (very slow / hung), restore the native buttons so the
+    // user isn't stranded on a skeleton. If the call resolves later, applyEnhancement runs normally.
+    this.maxWaitTimer = setTimeout(() => {
+      this.maxWaitTimer = null;
+      if (this.buttonsPhase !== 'loading') return;
+      this.debugLog.warn('ThirdIronButtons.maxWaitFallback', { maxWaitMs: this.MAX_WAIT_MS });
+      this.enterPassthrough('maxWaitFallback');
+    }, this.MAX_WAIT_MS);
+  }
+
+  /**
+   * Commit the 'enhanced' phase so the template renders our buttons. If the skeleton is currently
+   * visible, defer the swap until it has been shown for at least SKELETON_MIN_VISIBLE_MS so it
+   * can't flash-and-vanish.
+   */
+  private commitEnhanced(): void {
+    if (this.maxWaitTimer) {
+      clearTimeout(this.maxWaitTimer);
+      this.maxWaitTimer = null;
+    }
+    if (this.skeletonDelayTimer) {
+      clearTimeout(this.skeletonDelayTimer);
+      this.skeletonDelayTimer = null;
+    }
+    if (this.enhanceCommitTimer) {
+      clearTimeout(this.enhanceCommitTimer);
+      this.enhanceCommitTimer = null;
+    }
+
+    const elapsed = this.skeletonShownAt !== null ? Date.now() - this.skeletonShownAt : 0;
+    const remaining = this.SKELETON_MIN_VISIBLE_MS - elapsed;
+
+    if (this.showSkeleton && remaining > 0) {
+      this.enhanceCommitTimer = setTimeout(() => {
+        this.enhanceCommitTimer = null;
+        this.finalizeEnhanced();
+      }, remaining);
+      return;
+    }
+
+    this.finalizeEnhanced();
+  }
+
+  private finalizeEnhanced(): void {
+    this.showSkeleton = false;
+    this.skeletonShownAt = null;
+    this.buttonsPhase = 'enhanced';
+  }
+
+  /**
+   * Leave our UI out entirely and show the native Primo buttons. Used when a record is not
+   * enhance-eligible, when the settled result has no TI content, or as the max-wait fallback.
+   */
+  private enterPassthrough(reason: string): void {
+    this.clearPhaseTimers();
+    this.resetEnhancementState();
+    this.showSkeleton = false;
+    this.skeletonShownAt = null;
+    this.buttonsPhase = 'passthrough';
+
+    const hostElem = this.elementRef.nativeElement as HTMLElement;
+    const restoredCount = this.restorePrimoOnlineAvailability(hostElem);
+    this.debugLog.debug('ThirdIronButtons.restorePrimoOnlineAvailability', {
+      reason,
+      restoredCount,
+    });
+    // We render nothing in this case; collapse our wrapper so the host flex container's
+    // gap doesn't apply between us and the sibling `nde-online-availability`.
+    const wrapperHidden = this.hideHostWrapper(hostElem);
+    this.debugLog.debug('ThirdIronButtons.hideHostWrapper', {
+      reason,
+      wrapperHidden,
+    });
+  }
+
+  private clearPhaseTimers(): void {
+    if (this.skeletonDelayTimer) {
+      clearTimeout(this.skeletonDelayTimer);
+      this.skeletonDelayTimer = null;
+    }
+    if (this.enhanceCommitTimer) {
+      clearTimeout(this.enhanceCommitTimer);
+      this.enhanceCommitTimer = null;
+    }
+    if (this.maxWaitTimer) {
+      clearTimeout(this.maxWaitTimer);
+      this.maxWaitTimer = null;
+    }
   }
 
   private hasThirdIronAdditions(displayInfo: DisplayWaterfallResponse | null): boolean {

--- a/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
+++ b/src/app/third-iron-module/third-iron-buttons/third-iron-buttons.component.ts
@@ -49,7 +49,7 @@ import { PrimoAvailabilityDomController } from 'src/app/shared/primo-availabilit
   ],
   templateUrl: './third-iron-buttons.component.html',
   styleUrls: ['./third-iron-buttons.component.scss'],
-  providers: [SearchEntityService],
+  providers: [SearchEntityService, PrimoAvailabilityDomController],
   encapsulation: ViewEncapsulation.None,
 })
 export class ThirdIronButtonsComponent {
@@ -115,12 +115,6 @@ export class ThirdIronButtonsComponent {
   private enhanceCommitTimer: ReturnType<typeof setTimeout> | null = null;
   private maxWaitTimer: ReturnType<typeof setTimeout> | null = null;
 
-  // Owns all DOM coordination with the host Primo `nde-online-availability` element (hiding,
-  // restoring, and observing for late/re-renders) and the `<ng-component>` wrapper. Kept public so
-  // the side-effects can be spied in tests. Because we're injected *before* the native element, the
-  // eager one-shot hide can run before Primo has created it — the observer covers that race.
-  readonly availabilityDom = new PrimoAvailabilityDomController();
-
   // Expose enum to template
   ViewOptionType = ViewOptionType;
 
@@ -170,6 +164,9 @@ export class ThirdIronButtonsComponent {
     private configService: ConfigService,
     private debugLog: DebugLogService,
     private translationService: TranslationService,
+    // Owns all DOM coordination with the host Primo `nde-online-availability` element (hiding,
+    // restoring, and observing for late/re-renders) and the `<ng-component>` wrapper.
+    readonly availabilityDom: PrimoAvailabilityDomController,
     private destroyRef: DestroyRef,
     elementRef: ElementRef
   ) {


### PR DESCRIPTION
## Summary - [BZ-10062](https://thirdiron.atlassian.net/browse/BZ-10062)

Add a skeleton + placeholder for loading buttons until we have a response from the Third Iron api. This prevents the original Primo buttons being shown briefly, then replaced with the TI set of buttons:

<img width="944" height="627" alt="CleanShot 2026-07-07 at 12 26 08" src="https://github.com/user-attachments/assets/bf168129-4f29-48a6-9ef5-56eda02573b2" />

## Implementation Notes

<!-- Optional: Any file / API changes done to accomplish the larger goal laid out in the summary.-->

1. ​There was a bit of refactoring to the third-iron-buttons.components.ts file as well to move the dom related functions out into their own file.
2. There are three timing pieces added here: 
  a) skeleton delay - only show the skeleton if loading exceeds 150ms, so cached/fast responses don't show the placeholder at all, 
  b) min time visible for skeleton - once shown, the skeleton stays for at least 400ms so it doesn't just flash on screen and disapear too soon, 
  c) max-wait fallback - if we haven't received a response from the TI API for 8s the original Primo buttons are restored so the user doesn't sit indefinitely on the skeleton
3. Track all these timings with the following phases:
    - 'idle'        : nothing decided yet (initial)
    - 'loading'     : eligible record, LibKey call in-flight; native buttons hidden, skeleton reserved
    - 'enhanced'    : LibKey settled with TI content; render our buttons
    - 'passthrough' : not eligible / no TI content; native Primo buttons shown, we render nothing


## Deploy Prerequisites

- None

## Deploy Precautions


- None

## Deploy Informational Notes


- None



[BZ-10062]: https://thirdiron.atlassian.net/browse/BZ-10062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live Primo host DOM (hide/restore/observer) and async timing on the main enhancement path; behavior is heavily unit-tested but edge cases around slow APIs and record navigation warrant QA in fulldisplay.
> 
> **Overview**
> Fixes **BZ-10062** by stopping native Primo online-availability buttons from flashing before Third Iron buttons appear while the LibKey call is in flight.
> 
> **Third Iron buttons** now use render phases (`loading` → `enhanced` or `passthrough`): for enhance-eligible records, native `nde-online-availability` is hidden **immediately**, a reserved **skeleton** shows only after **150ms** (skipped for fast responses), stays at least **400ms** once visible, and **8s** max-wait restores native UI if the API never settles. Actual TI buttons render only in the `enhanced` phase; the pipeline is subscribed in `ngOnInit` so phase transitions run even when the template is not on the enhanced branch.
> 
> Primo DOM coordination moves into **`PrimoAvailabilityDomController`** (hide/restore availability, `MutationObserver` for late/re-render races, `ng-component` wrapper collapse for flex gap) with dedicated unit tests; component tests use a DI spy and add **anti-flash** `fakeAsync` coverage.
> 
> Styles add `!important` hide for marked native elements and skeleton shimmer (with reduced-motion). Dependabot **open PR limit** drops from 10 to **2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50df08f9cbdedd4775b90675416560ee63e98efb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->