### PR TITLE
Consider records with a contentType of "review" as an article - bz 10843

### DIFF
--- a/src/app/services/search-entity.service.spec.ts
+++ b/src/app/services/search-entity.service.spec.ts
@@ -37,6 +37,23 @@ describe('SearchEntityService', () => {
     expect(service).toBeTruthy();
   });
 
+  describe('isArticle', () => {
+    it('returns true when contentType is article', () => {
+      const entity = makeEntity({ type: 'article' });
+      expect(service.isArticle(entity)).toBe(true);
+    });
+
+    it('returns true when contentType is review', () => {
+      const entity = makeEntity({ type: 'review' });
+      expect(service.isArticle(entity)).toBe(true);
+    });
+
+    it('returns false when contentType is neither article nor review', () => {
+      const entity = makeEntity({ type: 'journal' });
+      expect(service.isArticle(entity)).toBe(false);
+    });
+  });
+
   describe('shouldEnhanceCover', () => {
     it('returns true for an article with ISSN and no DOI', () => {
       const entity = makeEntity({ type: 'article', issn: ['1234-5678'] });

--- a/src/app/services/search-entity.service.spec.ts
+++ b/src/app/services/search-entity.service.spec.ts
@@ -48,7 +48,12 @@ describe('SearchEntityService', () => {
       expect(service.isArticle(entity)).toBe(true);
     });
 
-    it('returns false when contentType is neither article nor review', () => {
+    it('returns true when contentType is video', () => {
+      const entity = makeEntity({ type: 'video' });
+      expect(service.isArticle(entity)).toBe(true);
+    });
+
+    it('returns false when contentType is neither article, review, nor video', () => {
       const entity = makeEntity({ type: 'journal' });
       expect(service.isArticle(entity)).toBe(false);
     });

--- a/src/app/services/search-entity.service.ts
+++ b/src/app/services/search-entity.service.ts
@@ -80,7 +80,7 @@ export class SearchEntityService {
       if (result.pnx.display && result.pnx.display.type) {
         var contentType = result.pnx.display.type[0]?.trim().toLowerCase();
 
-        if (contentType?.indexOf('article') > -1) {
+        if (contentType?.indexOf('article') > -1 || contentType?.indexOf('review') > -1) {
           validation = true;
         }
       }

--- a/src/app/services/search-entity.service.ts
+++ b/src/app/services/search-entity.service.ts
@@ -80,7 +80,11 @@ export class SearchEntityService {
       if (result.pnx.display && result.pnx.display.type) {
         var contentType = result.pnx.display.type[0]?.trim().toLowerCase();
 
-        if (contentType?.indexOf('article') > -1 || contentType?.indexOf('review') > -1) {
+        if (
+          contentType?.indexOf('article') > -1 ||
+          contentType?.indexOf('review') > -1 ||
+          contentType?.indexOf('video') > -1
+        ) {
           validation = true;
         }
       }

--- a/src/app/services/search-entity.service.ts
+++ b/src/app/services/search-entity.service.ts
@@ -6,6 +6,10 @@ import { EntityType } from '../shared/entity-type.enum';
   providedIn: 'root',
 })
 export class SearchEntityService {
+  // Primo content types we treat as articles: each is looked up by DOI
+  // through the article endpoint.
+  private readonly articleContentTypes = ['article', 'review', 'video'];
+
   constructor() {}
 
   isFiltered = (result: SearchEntity): boolean => {
@@ -81,9 +85,9 @@ export class SearchEntityService {
         const contentType = result.pnx.display.type[0]?.trim().toLowerCase();
 
         if (
-          contentType?.indexOf('article') > -1 ||
-          contentType?.indexOf('review') > -1 ||
-          contentType?.indexOf('video') > -1
+          this.articleContentTypes.some(
+            articleContentType => contentType?.indexOf(articleContentType) > -1
+          )
         ) {
           validation = true;
         }

--- a/src/app/services/search-entity.service.ts
+++ b/src/app/services/search-entity.service.ts
@@ -16,7 +16,7 @@ export class SearchEntityService {
 
     // if (result && result.delivery) {
     //   if (result.delivery.deliveryCategory && result.delivery.deliveryCategory.length > 0) {
-    //     var deliveryCategory = result.delivery.deliveryCategory[0].trim().toLowerCase();
+    //     const deliveryCategory = result.delivery.deliveryCategory[0].trim().toLowerCase();
 
     //     if (deliveryCategory === "alma-p" && !showPrintRecords()) {
     //       validation = true;
@@ -74,11 +74,11 @@ export class SearchEntityService {
   };
 
   isArticle = (result: SearchEntity): boolean => {
-    var validation = false;
+    let validation = false;
 
     if (result && result.pnx) {
       if (result.pnx.display && result.pnx.display.type) {
-        var contentType = result.pnx.display.type[0]?.trim().toLowerCase();
+        const contentType = result.pnx.display.type[0]?.trim().toLowerCase();
 
         if (
           contentType?.indexOf('article') > -1 ||
@@ -94,11 +94,11 @@ export class SearchEntityService {
   };
 
   isJournal = (result: SearchEntity): boolean => {
-    var validation = false;
+    let validation = false;
 
     if (result && result.pnx) {
       if (result.pnx.display && result.pnx.display.type) {
-        var contentType = result.pnx.display.type[0]?.trim().toLowerCase();
+        const contentType = result.pnx.display.type[0]?.trim().toLowerCase();
 
         if (contentType?.indexOf('journal') > -1) {
           validation = true;
@@ -110,7 +110,7 @@ export class SearchEntityService {
   };
 
   getIssn = (result: SearchEntity): string => {
-    var issn = '';
+    let issn = '';
 
     if (result && result.pnx && result.pnx.addata) {
       if (result.pnx.addata.issn) {
@@ -151,7 +151,7 @@ export class SearchEntityService {
   };
 
   getDoi = (result: SearchEntity): string => {
-    var doi = '';
+    let doi = '';
     if (result && result.pnx) {
       if (result.pnx.addata && result.pnx.addata.doi) {
         if (result.pnx.addata.doi[0]) {


### PR DESCRIPTION
## Summary - [BZ-10843](https://thirdiron.atlassian.net/browse/BZ-10843)

<!--Required section. The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Ensure we can enhance as many records as we can, including these reviews

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

This is the Primo NDE version of https://github.com/thirdiron/browzine-discovery-service-adapters/pull/157

I added a couple very basic unit tests... think that's enough?

## Deploy Prerequisites

<!-- Things that must be completed before deployment can safely proceed. Delete any of the items below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Precautions

<!--Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Informational Notes

<!--Things that are not concerns that would hold up a deployment or shape how a deployment is executed, but may be useful to know about when preparing for a deployment or after a deployment is completed. Delete any of the notices below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None



[BZ-10843]: https://thirdiron.atlassian.net/browse/BZ-10843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized classification change with new unit tests; no auth, data migration, or API contract changes.
> 
> **Overview**
> **Expands which Primo NDE records count as articles** so BrowZine enhancement (covers, buttons, DOI article lookup) applies to more content—not only `article`.
> 
> `SearchEntityService.isArticle` now matches display types against a shared list: `article`, `review`, and `video` (substring match, same as before for articles). A short comment documents that these types use the article/DOI endpoint.
> 
> Unit tests cover `isArticle` for all three positive cases and `journal` as negative. Minor `var` → `let`/`const` cleanup elsewhere in the service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e88a3eca46beeb11254bd896ee6e5aeb6a9bbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->