### PR TITLE
Deployment 2026-07-30 (Thu)

### DIFF
--- a/src/app/services/search-entity.service.spec.ts
+++ b/src/app/services/search-entity.service.spec.ts
@@ -37,6 +37,23 @@ describe('SearchEntityService', () => {
     expect(service).toBeTruthy();
   });
 
+  describe('isArticle', () => {
+    it('returns true when contentType is article', () => {
+      const entity = makeEntity({ type: 'article' });
+      expect(service.isArticle(entity)).toBe(true);
+    });
+
+    it('returns true when contentType is review', () => {
+      const entity = makeEntity({ type: 'review' });
+      expect(service.isArticle(entity)).toBe(true);
+    });
+
+    it('returns false when contentType is neither article nor review', () => {
+      const entity = makeEntity({ type: 'journal' });
+      expect(service.isArticle(entity)).toBe(false);
+    });
+  });
+
   describe('shouldEnhanceCover', () => {
     it('returns true for an article with ISSN and no DOI', () => {
       const entity = makeEntity({ type: 'article', issn: ['1234-5678'] });

--- a/src/app/services/search-entity.service.spec.ts
+++ b/src/app/services/search-entity.service.spec.ts
@@ -48,7 +48,12 @@ describe('SearchEntityService', () => {
       expect(service.isArticle(entity)).toBe(true);
     });
 
-    it('returns false when contentType is neither article nor review', () => {
+    it('returns true when contentType is video', () => {
+      const entity = makeEntity({ type: 'video' });
+      expect(service.isArticle(entity)).toBe(true);
+    });
+
+    it('returns false when contentType is neither article, review, nor video', () => {
       const entity = makeEntity({ type: 'journal' });
       expect(service.isArticle(entity)).toBe(false);
     });

--- a/src/app/services/search-entity.service.ts
+++ b/src/app/services/search-entity.service.ts
@@ -80,7 +80,7 @@ export class SearchEntityService {
       if (result.pnx.display && result.pnx.display.type) {
         var contentType = result.pnx.display.type[0]?.trim().toLowerCase();
 
-        if (contentType?.indexOf('article') > -1) {
+        if (contentType?.indexOf('article') > -1 || contentType?.indexOf('review') > -1) {
           validation = true;
         }
       }

--- a/src/app/services/search-entity.service.ts
+++ b/src/app/services/search-entity.service.ts
@@ -80,7 +80,11 @@ export class SearchEntityService {
       if (result.pnx.display && result.pnx.display.type) {
         var contentType = result.pnx.display.type[0]?.trim().toLowerCase();
 
-        if (contentType?.indexOf('article') > -1 || contentType?.indexOf('review') > -1) {
+        if (
+          contentType?.indexOf('article') > -1 ||
+          contentType?.indexOf('review') > -1 ||
+          contentType?.indexOf('video') > -1
+        ) {
           validation = true;
         }
       }

--- a/src/app/services/search-entity.service.ts
+++ b/src/app/services/search-entity.service.ts
@@ -6,6 +6,10 @@ import { EntityType } from '../shared/entity-type.enum';
   providedIn: 'root',
 })
 export class SearchEntityService {
+  // Primo content types we treat as articles: each is looked up by DOI
+  // through the article endpoint.
+  private readonly articleContentTypes = ['article', 'review', 'video'];
+
   constructor() {}
 
   isFiltered = (result: SearchEntity): boolean => {
@@ -81,9 +85,9 @@ export class SearchEntityService {
         const contentType = result.pnx.display.type[0]?.trim().toLowerCase();
 
         if (
-          contentType?.indexOf('article') > -1 ||
-          contentType?.indexOf('review') > -1 ||
-          contentType?.indexOf('video') > -1
+          this.articleContentTypes.some(
+            articleContentType => contentType?.indexOf(articleContentType) > -1
+          )
         ) {
           validation = true;
         }

--- a/src/app/services/search-entity.service.ts
+++ b/src/app/services/search-entity.service.ts
@@ -16,7 +16,7 @@ export class SearchEntityService {
 
     // if (result && result.delivery) {
     //   if (result.delivery.deliveryCategory && result.delivery.deliveryCategory.length > 0) {
-    //     var deliveryCategory = result.delivery.deliveryCategory[0].trim().toLowerCase();
+    //     const deliveryCategory = result.delivery.deliveryCategory[0].trim().toLowerCase();
 
     //     if (deliveryCategory === "alma-p" && !showPrintRecords()) {
     //       validation = true;
@@ -74,11 +74,11 @@ export class SearchEntityService {
   };
 
   isArticle = (result: SearchEntity): boolean => {
-    var validation = false;
+    let validation = false;
 
     if (result && result.pnx) {
       if (result.pnx.display && result.pnx.display.type) {
-        var contentType = result.pnx.display.type[0]?.trim().toLowerCase();
+        const contentType = result.pnx.display.type[0]?.trim().toLowerCase();
 
         if (
           contentType?.indexOf('article') > -1 ||
@@ -94,11 +94,11 @@ export class SearchEntityService {
   };
 
   isJournal = (result: SearchEntity): boolean => {
-    var validation = false;
+    let validation = false;
 
     if (result && result.pnx) {
       if (result.pnx.display && result.pnx.display.type) {
-        var contentType = result.pnx.display.type[0]?.trim().toLowerCase();
+        const contentType = result.pnx.display.type[0]?.trim().toLowerCase();
 
         if (contentType?.indexOf('journal') > -1) {
           validation = true;
@@ -110,7 +110,7 @@ export class SearchEntityService {
   };
 
   getIssn = (result: SearchEntity): string => {
-    var issn = '';
+    let issn = '';
 
     if (result && result.pnx && result.pnx.addata) {
       if (result.pnx.addata.issn) {
@@ -151,7 +151,7 @@ export class SearchEntityService {
   };
 
   getDoi = (result: SearchEntity): string => {
-    var doi = '';
+    let doi = '';
     if (result && result.pnx) {
       if (result.pnx.addata && result.pnx.addata.doi) {
         if (result.pnx.addata.doi[0]) {


### PR DESCRIPTION
# Release Notes - [See All Jiras](https://thirdiron.atlassian.net/issues/?jql=key%20in%20(%22BZ-10843%22))

- [BZ-10843](https://thirdiron.atlassian.net/browse/BZ-10843)
  - #128 - Consider records with a contentType of "review" as an article - bz 10843

# Deploy Prerequisites

- None

# Deploy Precautions

- None

# Deploy Information Notes

- None

# Pre-Deploy Checklist

- [ ] QA: Clicked through each Jira link in this PR description and confirmed it is set to "Ready to Ship", or there's a comment indicating it is ready to ship even if the status isn't "Ready to Ship"
- [ ] QA: Confirmed nothing in our board for this system is still in "Integration Testing" or "PO Check"
- [ ] Developer: Confirmed the changes look as expected, and nothing seems too strange

# Post-Deploy Checklist

- [ ] Developer: Transition [all Jiras in this PR](https://thirdiron.atlassian.net/issues/?jql=key%20in%20(%22BZ-10843%22)) to "Shipped, QA Verifying" (use Bulk Edit if there's many issues)

@jmalone29 @kcarlson87

[BZ-10843]: https://thirdiron.atlassian.net/browse/BZ-10843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested change to search result classification with no auth or data-layer impact; main risk is misclassification if type strings overlap unexpectedly.
> 
> **Overview**
> Primo search results whose display type is **review** or **video** are now classified the same as **article** records in `SearchEntityService.isArticle`, so they follow the article/DOI enhancement path (covers, buttons, entity type) instead of being skipped.
> 
> Matching is still substring-based on the normalized type string, driven by a shared `articleContentTypes` list (`article`, `review`, `video`). Unit tests cover the new types and a non-article counterexample (`journal`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d13fc3a8ac34abff91cb1c85f879c76d9c36dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->